### PR TITLE
Fixes scale setting on 768p resolutions 

### DIFF
--- a/SonicMania/Objects/Menu/UIWinSize.c
+++ b/SonicMania/Objects/Menu/UIWinSize.c
@@ -132,9 +132,9 @@ void UIWinSize_SetupText(EntityUIWinSize *entityPtr)
 
         self->maxScale = height / SCREEN_YSIZE;
         if (self->selection < 1)
-            self->selection = self->maxScale - 1;
+            self->selection = self->maxScale;
 
-        if (self->selection >= self->maxScale)
+        if (self->selection > self->maxScale)
             self->selection = 1;
 
         char buffer[0x10];


### PR DESCRIPTION
The game should be able to fit 3 times in a 768p monitor, but the scale setting only goes up to 2x.

BTW, this is actually an issue in the original version of the game, not the decomp.