### PR TITLE
User DB value size fixes

### DIFF
--- a/SonicMania/Objects/Helpers/ReplayDB.c
+++ b/SonicMania/Objects/Helpers/ReplayDB.c
@@ -84,7 +84,7 @@ uint32 ReplayDB_AddReplay(uint8 zoneID, uint8 act, uint8 characterID, int32 scor
         uint32 UUID = API.GetUserDBRowUUID(globals->replayTableID, rowID);
         char createTime[24];
         sprintf_s(createTime, (int32)sizeof(createTime), "");
-        API.GetUserDBRowCreationTime(globals->replayTableID, rowID, createTime, 23, "%Y/%m/%d %H:%M:%S");
+        API.GetUserDBRowCreationTime(globals->replayTableID, rowID, createTime, sizeof(createTime) - 1, "%Y/%m/%d %H:%M:%S");
 
         LogHelpers_Print("Replay DB Added Entry");
         LogHelpers_Print("Created at %s", createTime);

--- a/SonicMania/Objects/Helpers/TimeAttackData.c
+++ b/SonicMania/Objects/Helpers/TimeAttackData.c
@@ -572,8 +572,8 @@ int32 TimeAttackData_AddDBRow(uint8 zoneID, uint8 act, uint8 characterID, uint8 
 
     uint32 uuid = API.GetUserDBRowUUID(globals->taTableID, rowID);
     char buf[0x20];
-    memset(buf, 0, 0x20 * sizeof(char));
-    API.GetUserDBRowCreationTime(globals->taTableID, rowID, buf, 23, "%Y/%m/%d %H:%M:%S");
+    memset(buf, 0, sizeof(buf));
+    API.GetUserDBRowCreationTime(globals->taTableID, rowID, buf, sizeof(buf) - 1, "%Y/%m/%d %H:%M:%S");
 
     LogHelpers_Print("Time Attack DB Added Entry");
     LogHelpers_Print("Created at %s", buf);

--- a/SonicMania/Objects/Menu/TimeAttackMenu.c
+++ b/SonicMania/Objects/Menu/TimeAttackMenu.c
@@ -437,10 +437,10 @@ void TimeAttackMenu_WatchReplay(int32 row, bool32 showGhost)
     LogHelpers_Print("uuid: %08X", uuid);
 
     int32 score       = 0;
-    int32 zoneID      = 0;
-    int32 act         = 0;
-    int32 characterID = 0;
-    int32 encore      = 0;
+    uint8 zoneID      = 0;
+    uint8 act         = 0;
+    uint8 characterID = 0;
+    uint8 encore      = 0;
     API.GetUserDBValue(globals->replayTableID, row, DBVAR_UINT32, "score", &score);
     API.GetUserDBValue(globals->replayTableID, row, DBVAR_UINT8, "zoneID", &zoneID);
     API.GetUserDBValue(globals->replayTableID, row, DBVAR_UINT8, "act", &act);

--- a/SonicMania/Objects/Menu/UIReplayCarousel.c
+++ b/SonicMania/Objects/Menu/UIReplayCarousel.c
@@ -300,7 +300,7 @@ void UIReplayCarousel_SetupVisibleReplayButtons(void)
             if (id >= self->sortedRowCount)
                 break;
             int32 row    = API.GetSortedUserDBRowID(globals->replayTableID, id);
-            int32 zoneID = 0xFF;
+            uint8 zoneID = 0xFF;
             API.GetUserDBValue(globals->replayTableID, row, DBVAR_UINT8, "zoneID", &zoneID);
             API.GetUserDBRowCreationTime(globals->replayTableID, row, buffer, 31, "%D");
             if (zoneID != 0xFF) {
@@ -527,11 +527,11 @@ void UIReplayCarousel_Draw_Carousel(void)
         if (id >= self->sortedRowCount)
             break;
 
-        int32 score        = 0;
-        uint16 zoneID      = 0;
-        uint16 act         = 0;
-        uint16 characterID = 0;
-        uint16 encore      = 0;
+        int32 score       = 0;
+        uint8 zoneID      = 0;
+        uint8 act         = 0;
+        uint8 characterID = 0;
+        uint8 encore      = 0;
 
         int32 row = API.GetSortedUserDBRowID(globals->replayTableID, id);
         API.GetUserDBValue(globals->replayTableID, row, DBVAR_UINT32, "score", &score);

--- a/SonicMania/Objects/Menu/UIReplayCarousel.c
+++ b/SonicMania/Objects/Menu/UIReplayCarousel.c
@@ -302,7 +302,7 @@ void UIReplayCarousel_SetupVisibleReplayButtons(void)
             int32 row    = API.GetSortedUserDBRowID(globals->replayTableID, id);
             uint8 zoneID = 0xFF;
             API.GetUserDBValue(globals->replayTableID, row, DBVAR_UINT8, "zoneID", &zoneID);
-            API.GetUserDBRowCreationTime(globals->replayTableID, row, buffer, 31, "%D");
+            API.GetUserDBRowCreationTime(globals->replayTableID, row, buffer, sizeof(buffer) - 1, "%D");
             if (zoneID != 0xFF) {
                 RSDK.InitString(&self->zoneNameText[i], "", 0);
                 Localization_GetZoneName(&self->zoneNameText[i], zoneID);


### PR DESCRIPTION
These mismatched value types and sizes cause bugs on big-endian CPUs. I've also replaced some hardcoded array sizes with `sizeof`, fixing one bugged size in the process.