### PR TITLE
Fix crash in the PGZ2 outro.

### DIFF
--- a/SonicMania/Objects/PGZ/PSZ2Outro.c
+++ b/SonicMania/Objects/PGZ/PSZ2Outro.c
@@ -188,8 +188,8 @@ bool32 PSZ2Outro_Cutscene_RubyWarp(EntityCutsceneSeq *host)
 {
     RSDK_THIS(PSZ2Outro);
 
-    MANIA_GET_PLAYER(player1, player2, camera);
-    UNUSED(camera);
+    EntityPlayer *player1 = RSDK_GET_ENTITY(SLOT_PLAYER1, Player);                                                                                       \
+    EntityPlayer *player2 = RSDK_GET_ENTITY(SLOT_PLAYER2, Player);                                                                                       \
 
     EntityPSZEggman *eggman = self->eggman;
     EntityFXRuby *fxRuby    = NULL;
@@ -231,8 +231,9 @@ bool32 PSZ2Outro_Cutscene_RubyWarp(EntityCutsceneSeq *host)
 
             if (host->timer >= host->storedTimer + 52) {
                 int32 id = 0;
-                for (int32 angle = 0; angle < 0x80; angle += 0x40) {
-                    EntityPlayer *player = RSDK_GET_ENTITY(id++, Player);
+		EntityPlayer *players[2] = {player1, player2};
+                for (int32 i = 0; i < 2; ++i) {
+                    EntityPlayer *player = players[i];
                     if (player->classID != Player->classID)
                         break;
 
@@ -240,7 +241,7 @@ bool32 PSZ2Outro_Cutscene_RubyWarp(EntityCutsceneSeq *host)
 
                     int32 valX = (player->position.x - player->position.x) >> 3;
                     int32 valY =
-                        (0xA00 * RSDK.Sin256(2 * (angle + host->timer - host->storedTimer)) + (eggman->position.y - 0x200000) - player->position.y)
+                        (0xA00 * RSDK.Sin256(2 * ((i * 0x40) + host->timer - host->storedTimer)) + (eggman->position.y - 0x200000) - player->position.y)
                         >> 3;
 
                     player->position.x += valX;

--- a/SonicMania/Objects/PGZ/PSZ2Outro.c
+++ b/SonicMania/Objects/PGZ/PSZ2Outro.c
@@ -233,7 +233,7 @@ bool32 PSZ2Outro_Cutscene_RubyWarp(EntityCutsceneSeq *host)
                 int32 id = 0;
                 for (int32 angle = 0; angle < 0x80; angle += 0x40) {
                     EntityPlayer *player = RSDK_GET_ENTITY(id++, Player);
-                    if (!player || player->classID == TYPE_BLANK)
+                    if (player->classID != Player->classID)
                         break;
 
                     RSDK.SetSpriteAnimation(player->aniFrames, ANI_FAN, &player->animator, false, 0);

--- a/SonicMania/Objects/PGZ/PSZ2Outro.c
+++ b/SonicMania/Objects/PGZ/PSZ2Outro.c
@@ -231,24 +231,23 @@ bool32 PSZ2Outro_Cutscene_RubyWarp(EntityCutsceneSeq *host)
 
             if (host->timer >= host->storedTimer + 52) {
                 int32 id = 0;
-		EntityPlayer *players[2] = {player1, player2};
+                EntityPlayer *players[2] = {player1, player2};
                 for (int32 i = 0; i < 2; ++i) {
                     EntityPlayer *player = players[i];
-                    if (player->classID != Player->classID)
-                        break;
+                    if (player->classID == Player->classID) {
+                        RSDK.SetSpriteAnimation(player->aniFrames, ANI_FAN, &player->animator, false, 0);
 
-                    RSDK.SetSpriteAnimation(player->aniFrames, ANI_FAN, &player->animator, false, 0);
+                        int32 valX = (player->position.x - player->position.x) >> 3;
+                        int32 valY =
+                            (0xA00 * RSDK.Sin256(2 * ((i * 0x40) + host->timer - host->storedTimer)) + (eggman->position.y - 0x200000) - player->position.y)
+                            >> 3;
 
-                    int32 valX = (player->position.x - player->position.x) >> 3;
-                    int32 valY =
-                        (0xA00 * RSDK.Sin256(2 * ((i * 0x40) + host->timer - host->storedTimer)) + (eggman->position.y - 0x200000) - player->position.y)
-                        >> 3;
-
-                    player->position.x += valX;
-                    player->position.y += valY;
-                    player->state          = Player_State_Static;
-                    player->tileCollisions = TILECOLLISION_NONE;
-                    player->onGround       = false;
+                        player->position.x += valX;
+                        player->position.y += valY;
+                        player->state          = Player_State_Static;
+                        player->tileCollisions = TILECOLLISION_NONE;
+                        player->onGround       = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ohhhhhhh where the hell do I begin with this...

Okay, so, if you complete PGZ2 while playing without Tails or Knuckles as a sidekick and while you have a Fire Shield, then the
game will crash during the cutscene right when the first 'pulse' of the Phantom Ruby happens.

This is caused by the shield being loaded into player 2's object slot. The cutscene tries to update both players, mistaking the shield for the sidekick character. This causes it to overwrite the shield's state with player state, causing the shield player pointer to be replaced with a pointer to a player object function. This would cause the shield object's update function to crash the game.

The original code was able to tell that the second player slot had a shield in it by comparing its classID to that of the first player,
but this decompilation got this incorrect and instead merely checked that the slot wasn't empty. It also redundantly checked if the pointer to the slot was `NULL`, which is impossible.

Correcting this fixes the crash. Good riddance, too: that bug's been driving me crazy for over a month! I thought I'd fixed it in [this PR](https://github.com/Rubberduckycooly/RSDKv5-Decompilation/pull/111), but it turns out that I'd just fixed a completely unrelated bug that, at the time, was crashing my MinGW builds.

Because the conditions to trigger this bug were so specific (have a Fire Shield, and don't have Tails or Knuckles as a companion), I never figured out how to consistently recreate this crash until now.

Aaaaaaaaaaaaaaaaaaaaa.