### PR TITLE
Fix Insta-Shield hitbox

### DIFF
--- a/SonicMania/Objects/Global/Player.c
+++ b/SonicMania/Objects/Global/Player.c
@@ -2470,8 +2470,8 @@ bool32 Player_CheckBadnikTouch(EntityPlayer *player, void *e, Hitbox *entityHitb
 #endif
 
     EntityShield *shield = RSDK_GET_ENTITY(Player->playerCount + player->playerID, Shield);
+    Hitbox tempHitbox;
     if (shield->classID == Shield->classID && shield->state == Shield_State_Insta) {
-        Hitbox tempHitbox;
 
         tempHitbox.left   = (playerHitbox->left << 1) - (playerHitbox->left >> 1);
         tempHitbox.top    = (playerHitbox->top << 1) - (playerHitbox->top >> 1);


### PR DESCRIPTION
The `tempHitbox` variable was only valid inside of the if, which lead to undefined behavior when using its address afterwards. While not an issue on MSVC, more aggressive compilers like GCC (O3) and Clang (O1) took advantage of this range limit to further optimize the code, and caused all sorts of bugs on Linux/Android.