### PR TITLE
Fix graphical corruption in the Android and Switch rev01 video filter menu

### DIFF
--- a/SonicMania/Objects/Menu/UIPicture.c
+++ b/SonicMania/Objects/Menu/UIPicture.c
@@ -24,13 +24,8 @@ void UIPicture_Draw(void)
 {
     RSDK_THIS(UIPicture);
 
-    // Bug Details:
-    // This should use zoneID in the CopyPalette params right?
-    // using zonePalette would just be 0 or 1 instead of 0-12 or so that you'd expect...
-
-    if (self->zonePalette)
-        RSDK.CopyPalette((self->zonePalette >> 3) + 1, 32 * self->zonePalette, 0, 224, 32);
-
+    RSDK.CopyPalette((self->zonePalette >> 3) + 1, 32 * self->zoneID, 0, 224, 32);
+    
     RSDK.DrawSprite(&self->animator, NULL, false);
 }
 

--- a/SonicMania/Objects/Menu/UIPicture.c
+++ b/SonicMania/Objects/Menu/UIPicture.c
@@ -24,8 +24,11 @@ void UIPicture_Draw(void)
 {
     RSDK_THIS(UIPicture);
 
-    RSDK.CopyPalette((self->zonePalette >> 3) + 1, 32 * self->zoneID, 0, 224, 32);
-    
+    if (self->zoneID)
+        RSDK.CopyPalette((self->zonePalette >> 3) + 1, 32 * self->zonePalette, 0, 224, 32);
+    else if (self->zonePalette)
+        RSDK.CopyPalette((self->zonePalette >> 3) + 1, 32 * self->zoneID, 0, 224, 32);
+
     RSDK.DrawSprite(&self->animator, NULL, false);
 }
 

--- a/SonicMania/Objects/Menu/UIPicture.c
+++ b/SonicMania/Objects/Menu/UIPicture.c
@@ -24,10 +24,17 @@ void UIPicture_Draw(void)
 {
     RSDK_THIS(UIPicture);
 
-    if (self->zoneID)
+#if MANIA_USE_PLUS
+    // Bug Details:
+    // This should use zoneID in the CopyPalette params right?
+    // using zonePalette would just be 0 or 1 instead of 0-12 or so that you'd expect...
+    if (self->zonePalette)
         RSDK.CopyPalette((self->zonePalette >> 3) + 1, 32 * self->zonePalette, 0, 224, 32);
-    else if (self->zonePalette)
-        RSDK.CopyPalette((self->zonePalette >> 3) + 1, 32 * self->zoneID, 0, 224, 32);
+#else
+    // And from the looks of it, this is actually how Pre-Plus Mania handles this?
+    if (self->zonePalette)
+        RSDK.CopyPalette((self->zoneID >> 3) + 1, 32 * self->zoneID, 0, 224, 32);
+#endif
 
     RSDK.DrawSprite(&self->animator, NULL, false);
 }


### PR DESCRIPTION
Fixed the graphical corruption happening in the rev01 Android and Switch video filter settings menu.

Closes https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation/issues/171

