### PR TITLE
Fix build when disabling the editor

### DIFF
--- a/SonicMania/GameLink.h
+++ b/SonicMania/GameLink.h
@@ -1731,7 +1731,6 @@ typedef struct {
         RSDK.SetEditableVar(type, buffer, (uint8)object->classID, offsetof(Entity##object, var) + sizeof(arrType) * i);                              \
     }
 
-#if RETRO_INCLUDE_EDITOR
 // Some extra precaution to prevent crashes in editor
 #define RSDK_ACTIVE_VAR(object, var)                                                                                                                 \
     if (object) {                                                                                                                                    \
@@ -1742,6 +1741,7 @@ typedef struct {
     }
 #define RSDK_ENUM_VAR(name, var) RSDK.AddVarEnumValue(name)
 
+#if RETRO_INCLUDE_EDITOR
 #define RSDK_DRAWING_OVERLAY(isDrawingOverlay) SceneInfo->debugMode = isDrawingOverlay
 
 #if RETRO_REV0U

--- a/SonicMania/Objects/FBZ/WarpDoor.c
+++ b/SonicMania/Objects/FBZ/WarpDoor.c
@@ -388,6 +388,7 @@ void WarpDoor_DrawDebug(void)
         }
     }
 
+#if RETRO_INCLUDE_EDITOR
     if (SceneInfo->inEditor) {
         // added for RE2, it makes the scene a mess without this
         if (!showGizmos())
@@ -420,6 +421,7 @@ void WarpDoor_DrawDebug(void)
 
         RSDK_DRAWING_OVERLAY(false); // added for RE2
     }
+#endif
 }
 
 void WarpDoor_SetupHitbox(void)

--- a/SonicMania/Objects/MMZ/MatryoshkaBom.c
+++ b/SonicMania/Objects/MMZ/MatryoshkaBom.c
@@ -454,6 +454,7 @@ void MatryoshkaBom_State_Shrapnel(void)
     }
 }
 
+#if RETRO_INCLUDE_EDITOR
 void MatryoshkaBom_EditorDraw(void)
 {
     RSDK_THIS(MatryoshkaBom);
@@ -506,6 +507,7 @@ void MatryoshkaBom_EditorLoad(void)
     RSDK_ENUM_VAR("Medium", MATRYOSHKA_SIZE_MED);
     RSDK_ENUM_VAR("Small", MATRYOSHKA_SIZE_SMALL);
 }
+#endif
 
 void MatryoshkaBom_Serialize(void)
 {


### PR DESCRIPTION
Some macros aren't available when building without editor support. Add `#ifdef RETRO_INCLUDE_EDITOR` to prevent compile errors.