### PR TITLE
fix Silver Sonic's MSBomb projectile

### DIFF
--- a/SonicMania/Objects/SSZ/MSBomb.c
+++ b/SonicMania/Objects/SSZ/MSBomb.c
@@ -117,7 +117,7 @@ void MSBomb_State_SilverSonicExplode(void)
         bomb->velocity.y = yVel;
 
         bomb             = CREATE_ENTITY(MSBomb, INT_TO_VOID(true), self->position.x, self->position.y);
-        yVel             = -(yVel >> 1);
+        yVel             = yVel >> 1;
         bomb->velocity.x = -xVel;
         bomb->velocity.y = yVel;
 

--- a/SonicMania/Objects/SSZ/MSBomb.c
+++ b/SonicMania/Objects/SSZ/MSBomb.c
@@ -108,16 +108,15 @@ void MSBomb_State_SilverSonicExplode(void)
         }
 
         EntityMSBomb *bomb = CREATE_ENTITY(MSBomb, INT_TO_VOID(true), self->position.x, self->position.y);
-        yVel               = -yVel;
         bomb->velocity.x   = -xVel;
-        bomb->velocity.y   = yVel;
+        bomb->velocity.y   = -yVel;
 
         bomb             = CREATE_ENTITY(MSBomb, INT_TO_VOID(true), self->position.x, self->position.y);
         bomb->velocity.x = xVel;
-        bomb->velocity.y = yVel;
+        bomb->velocity.y = -yVel;
 
         bomb             = CREATE_ENTITY(MSBomb, INT_TO_VOID(true), self->position.x, self->position.y);
-        yVel             = yVel >> 1;
+        yVel             = -(yVel >> 1);
         bomb->velocity.x = -xVel;
         bomb->velocity.y = yVel;
 


### PR DESCRIPTION
fixes an issue where the latter two MSBomb projectiles from Silver Sonic would go down instead of up like in the original game.

solves a part of https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation/issues/184