### PR TITLE
Prevent Redz from flying

### DIFF
--- a/SonicMania/Objects/HPZ/Redz.c
+++ b/SonicMania/Objects/HPZ/Redz.c
@@ -154,9 +154,9 @@ void Redz_State_Turn(void)
 
     if (self->timer < 59) {
         self->timer++;
-        self->state = Redz_State_Walk;
     }
     else {
+        self->state = Redz_State_Walk;
         self->timer = 0;
         RSDK.SetSpriteAnimation(Redz->aniFrames, 0, &self->animator, true, 0);
         self->animator.frameID = 0;


### PR DESCRIPTION
The state would immediately get changed back to Walk, causing them to levitate.
Move the state change where it belongs.

Fixes #198.