### PR TITLE
TMZ2Outro: Fix missing Knuckles and slow ruby portal

### DIFF
--- a/SonicMania/GameVariables.h
+++ b/SonicMania/GameVariables.h
@@ -102,7 +102,9 @@ typedef enum {
     SLOT_PLAYER3    = 2,
     SLOT_PLAYER4    = 3,
     SLOT_POWERUP1   = 4,
+    SLOT_PLAYER5    = 4, // Used in TMZ2Outro
     SLOT_POWERUP2   = 5,
+    SLOT_PLAYER6    = 5, // Used in TMZ2Outro
     SLOT_POWERUP3   = 6,
     SLOT_POWERUP4   = 7,
     SLOT_POWERUP1_2 = 8,

--- a/SonicMania/Objects/TMZ/TMZ2Outro.c
+++ b/SonicMania/Objects/TMZ/TMZ2Outro.c
@@ -552,11 +552,11 @@ bool32 TMZ2Outro_Cutscene_OuttaHere(EntityCutsceneSeq *host)
     }
 
     if (host->timer == 300) {
-        foreach_active(PhantomRuby, ruby)
+        foreach_active(RubyPortal, portal)
         {
-            ruby->velocity.x  = 0x20000;
-            ruby->isPermanent = true;
-            ruby->active      = ACTIVE_NORMAL;
+            portal->velocity.x  = 0x20000;
+            portal->isPermanent = true;
+            portal->active      = ACTIVE_NORMAL;
         }
 
         RSDK_GET_ENTITY(SLOT_CAMERA1, Camera)->state = StateMachine_None;
@@ -600,17 +600,17 @@ bool32 TMZ2Outro_Cutscene_TeamEscape(EntityCutsceneSeq *host)
         player2->playerID = 1;
         Player_ChangeCharacter(player2, ID_TAILS);
 
-        EntityPlayer *player3 = RSDK_GET_ENTITY(SLOT_PLAYER3, Player);
+        EntityPlayer *player3 = RSDK_GET_ENTITY(SLOT_PLAYER4, Player);
         RSDK.CopyEntity(player3, player1, false);
         player3->playerID = 3;
         Player_ChangeCharacter(player3, ID_KNUCKLES);
 
-        EntityPlayer *player4 = RSDK_GET_ENTITY(SLOT_PLAYER4, Player);
+        EntityPlayer *player4 = RSDK_GET_ENTITY(SLOT_PLAYER5, Player);
         RSDK.CopyEntity(player4, player1, false);
         player4->playerID = 4;
         Player_ChangeCharacter(player4, ID_MIGHTY);
 
-        EntityPlayer *player5 = RSDK_GET_ENTITY(5, Player);
+        EntityPlayer *player5 = RSDK_GET_ENTITY(SLOT_PLAYER6, Player);
         RSDK.CopyEntity(player5, player1, false);
         player5->playerID = 5;
         Player_ChangeCharacter(player5, ID_RAY);


### PR DESCRIPTION
Attempts to fix the Encore escape cutscene:

- [X] Knuckles is missing
- [X] Ruby portal too slow / eggman not falling into the portal (actually the same issue)
- [ ] Level tiles not being removed from the level after getting sucked into the portal