### PR TITLE
Fix invalid Super form collisions

### DIFF
--- a/SonicMania/Objects/Global/Player.c
+++ b/SonicMania/Objects/Global/Player.c
@@ -2440,6 +2440,30 @@ bool32 Player_CheckAttacking(EntityPlayer *player, void *e)
 
     return attacking;
 }
+// This is identical to Player_CheckAttacking, except it's not checking for the player invincible timer.
+bool32 Player_CheckAttackingNoInvTimer(EntityPlayer *player, void *e)
+{
+    Entity *entity   = (Entity *)e;
+    int32 anim       = player->animator.animationID;
+    bool32 attacking = anim == ANI_JUMP || anim == ANI_SPINDASH;
+    switch (player->characterID) {
+        case ID_SONIC: attacking |= anim == ANI_DROPDASH; break;
+#if MANIA_USE_PLUS
+        case ID_MIGHTY: attacking |= anim == ANI_HAMMERDROP; break;
+#endif
+        case ID_TAILS:
+            if (!attacking && entity) {
+                attacking = anim == ANI_FLY || anim == ANI_FLY_TIRED || anim == ANI_FLY_LIFT;
+                if (player->position.y <= entity->position.y)
+                    return false;
+            }
+            break;
+        case ID_KNUCKLES: attacking |= anim == ANI_GLIDE || anim == ANI_GLIDE_SLIDE; break;
+        default: break;
+    }
+
+    return attacking;
+}
 bool32 Player_CheckBadnikTouch(EntityPlayer *player, void *e, Hitbox *entityHitbox)
 {
     Entity *entity = (Entity *)e;

--- a/SonicMania/Objects/Global/Player.h
+++ b/SonicMania/Objects/Global/Player.h
@@ -532,6 +532,8 @@ bool32 Player_HurtFlip(EntityPlayer *player);
 bool32 Player_ElementHurt(EntityPlayer *player, void *entity, int32 shield);
 // returns true if the player is in an "attacking" state
 bool32 Player_CheckAttacking(EntityPlayer *player, void *e);
+// returns true if the player is in an "attacking" state (but omits invincibility timer as being an "attacking" state)
+bool32 Player_CheckAttackingNoInvTimer(EntityPlayer *player, void *e);
 // checks if the player collided with an entity, this collision differs from the touch one above since it uses hammerdrop & instashield if appropriate
 bool32 Player_CheckBadnikTouch(EntityPlayer *player, void *entity, Hitbox *entityHitbox);
 // checks if the player is attacking the badnik, returns true if the player attacked the badnik, otherwise the player is hit and returns false

--- a/SonicMania/Objects/LRZ/TurretSwitch.c
+++ b/SonicMania/Objects/LRZ/TurretSwitch.c
@@ -80,7 +80,7 @@ void TurretSwitch_CheckPlayerCollisions(void)
     foreach_active(Player, player)
     {
         if (Player_CheckCollisionTouch(player, self, &ItemBox->hitboxItemBox)) {
-            if (Player_CheckAttacking(player, self) || player->state == Ice_PlayerState_Frozen) {
+            if (Player_CheckAttackingNoInvTimer(player, self) || player->state == Ice_PlayerState_Frozen) {
                 TurretSwitch_Break(self, player);
                 foreach_break;
             }

--- a/SonicMania/Objects/PGZ/DoorTrigger.c
+++ b/SonicMania/Objects/PGZ/DoorTrigger.c
@@ -44,7 +44,7 @@ void DoorTrigger_Update(void)
     else {
         foreach_active(Player, player)
         {
-            if (!player->sidekick && Player_CheckAttacking(player, self)) {
+            if (!player->sidekick && Player_CheckAttackingNoInvTimer(player, self)) {
                 if (Player_CheckCollisionTouch(player, self, &DoorTrigger->hitboxBulb[self->baseAnimator.frameID])) {
                     self->bulbAnimator.frameID = 1;
                     if (player->characterID == ID_KNUCKLES && player->animator.animationID == ANI_GLIDE) {

--- a/SonicMania/Objects/SSZ/FlowerPod.c
+++ b/SonicMania/Objects/SSZ/FlowerPod.c
@@ -89,7 +89,7 @@ void FlowerPod_State_Pod(void)
 
     foreach_active(Player, player)
     {
-        if (Player_CheckAttacking(player, self) && Player_CheckBadnikTouch(player, self, &FlowerPod->hitboxPod))
+        if (Player_CheckAttackingNoInvTimer(player, self) && Player_CheckBadnikTouch(player, self, &FlowerPod->hitboxPod))
             self->state = FlowerPod_State_Exploding;
     }
 }

--- a/SonicMania/Objects/SSZ/SilverSonic.c
+++ b/SonicMania/Objects/SSZ/SilverSonic.c
@@ -155,13 +155,7 @@ void SilverSonic_CheckPlayerCollisions_Ball(void)
         foreach_active(Player, player)
         {
             if (Player_CheckBadnikTouch(player, self, self->innerBox)) {
-                // Player_CheckAttacking is inlined here in the original, but the player->invincibleTimer != 0 check is removed.
-                // Instead of copying the entire function for removing a single condition, we'll manually set it to 0 before the call, then set it back.
-                int32 saveInvincibilityTimer = player->invincibleTimer;
-                player->invincibleTimer = 0;
-                if (Player_CheckAttacking(player, self)) {
-                    player->invincibleTimer = saveInvincibilityTimer;
-
+                if (Player_CheckAttackingNoInvTimer(player, self)) {
                     if (self->onGround) {
                         if (abs(player->velocity.x) <= 0x30000) {
                             player->groundVel  = self->groundVel;
@@ -213,7 +207,6 @@ void SilverSonic_CheckPlayerCollisions_Ball(void)
                     RSDK.PlaySfx(SilverSonic->sfxRebound, false, 255);
                 }
                 else {
-                    player->invincibleTimer = saveInvincibilityTimer;
                     Player_Hurt(player, self);
                 }
             }

--- a/SonicMania/PublicFunctions.c
+++ b/SonicMania/PublicFunctions.c
@@ -1908,6 +1908,7 @@ void InitPublicFunctions()
     ADD_PUBLIC_FUNC(Player_HurtFlip);
     ADD_PUBLIC_FUNC(Player_ElementHurt);
     ADD_PUBLIC_FUNC(Player_CheckAttacking);
+    ADD_PUBLIC_FUNC(Player_CheckAttackingNoInvTimer);
     ADD_PUBLIC_FUNC(Player_CheckBadnikTouch);
     ADD_PUBLIC_FUNC(Player_CheckBadnikBreak);
     ADD_PUBLIC_FUNC(Player_CheckBossHit);


### PR DESCRIPTION
Turns out multiple entities actually ignore the invincibilityTimer:
* SilverSonic
* TurretSwitch (Beta Lava Reef)
* DoorTrigger (PGZ1)
* FlowerPod (SSZ1)

Instead of doing the Silver Sonic workaround for Player_CheckAttacking, this commit creates a second function that specifically ignores invincibilityTimer.

Fixes #211.