### PR TITLE
Fix surfacing hatch offset

### DIFF
--- a/SonicMania/Objects/OOZ/Hatch.c
+++ b/SonicMania/Objects/OOZ/Hatch.c
@@ -364,7 +364,6 @@ void Hatch_State_Surfacing(void)
     if (self->timer >= self->depth) {
         self->timer      = 0;
         self->visible    = true;
-        self->position.x = player->position.x;
         self->position.y = player->position.y + 0x80000;
 
         RSDK.SetSpriteAnimation(Hatch->aniFrames, 1, &self->hatchAnimator, false, 0);


### PR DESCRIPTION
In the steam version, the object's `posx` isn't set, whereas in the decomp, the object's `posx` was set to the player's `posx`. 
Fixes #212