### PR TITLE
Make cutscene code more accurate

### DIFF
--- a/SonicMania/Objects/AIZ/AIZSetup.c
+++ b/SonicMania/Objects/AIZ/AIZSetup.c
@@ -339,7 +339,7 @@ void AIZSetup_CutsceneST_Setup(void)
                               AIZSetup_Cutscene_LoadGHZ, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_CALLBACK, AIZSetup_Cutscene_SkipCB);
+    CutsceneSeq_SetSkipTypeCallback(AIZSetup_Cutscene_SkipCB);
 #endif
 }
 
@@ -669,7 +669,7 @@ void AIZSetup_CutsceneK_Setup(void)
                               AIZSetup_CutsceneKnux_RubyImpact, AIZSetup_CutsceneKnux_RubyFX, AIZSetup_Cutscene_LoadGHZ, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_CALLBACK, AIZSetup_Cutscene_SkipCB);
+    CutsceneSeq_SetSkipTypeCallback(AIZSetup_Cutscene_SkipCB);
 #endif
 }
 

--- a/SonicMania/Objects/AIZ/EncoreIntro.c
+++ b/SonicMania/Objects/AIZ/EncoreIntro.c
@@ -19,9 +19,7 @@ void EncoreIntro_Update(void)
         {
             if (Player_CheckCollisionTouch(player, self, &self->hitbox)) {
                 EncoreIntro_SetupCutscene();
-                EntityCutsceneSeq *seq = RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq);
-                if (seq->classID)
-                    seq->skipType = SKIPTYPE_RELOADSCN;
+                CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
                 self->activated = true;
             }
         }
@@ -723,11 +721,7 @@ bool32 EncoreIntro_Cutscene_AIZEncoreTutorial(EntityCutsceneSeq *host)
             player->velocity.x = 0x20000;
         self->velocity.x = player->velocity.x;
         camera->target   = (Entity *)self;
-        if (RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq)->classID) {
-            EntityCutsceneSeq *cutsceneSeq = RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq);
-            cutsceneSeq->skipType          = SKIPTYPE_CALLBACK;
-            cutsceneSeq->skipCallback      = AIZEncoreTutorial_State_ReturnToCutscene;
-        }
+        CutsceneSeq_SetSkipTypeCallback(AIZEncoreTutorial_State_ReturnToCutscene);
         HUD_MoveOut();
         return true;
     }

--- a/SonicMania/Objects/AIZ/EncoreIntro.c
+++ b/SonicMania/Objects/AIZ/EncoreIntro.c
@@ -39,7 +39,7 @@ void EncoreIntro_Update(void)
         self->skipPart2 = false;
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+        CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
     }
 }
@@ -146,7 +146,7 @@ void EncoreIntro_SetupCutscene(void)
                               EncoreIntro_Cutscene_AwaitSaveFinish, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 }
 

--- a/SonicMania/Objects/CPZ/CPZ1Intro.c
+++ b/SonicMania/Objects/CPZ/CPZ1Intro.c
@@ -20,13 +20,7 @@ void CPZ1Intro_Update(void)
         }
         else {
             self->activated = true;
-            CutsceneSeq_StartSequence(self, CPZ1Intro_Cutscene_RubyWarp, CPZ1Intro_Cutscene_PostWarpDrop, CPZ1Intro_Cutscene_Waiting,
-                                      CPZ1Intro_Cutscene_ChemicalDrop, CPZ1Intro_Cutscene_PlayerChemicalReact, CPZ1Intro_Cutscene_ReadyStage,
-                                      StateMachine_None);
-
-#if MANIA_USE_PLUS
-            CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
-#endif
+            CPZ1Intro_SetupCutscene();
         }
     }
 }
@@ -59,6 +53,19 @@ void CPZ1Intro_StageLoad(void)
 
     CPZ1Intro->sfxChemDrop = RSDK.GetSfx("CPZ/ChemDrop.wav");
     CPZ1Intro->sfxDNABurst = RSDK.GetSfx("CPZ/DNABurst.wav");
+}
+
+void CPZ1Intro_SetupCutscene(void)
+{
+    RSDK_THIS(CPZ1Intro);
+
+    CutsceneSeq_StartSequence(self, CPZ1Intro_Cutscene_RubyWarp, CPZ1Intro_Cutscene_PostWarpDrop, CPZ1Intro_Cutscene_Waiting,
+                              CPZ1Intro_Cutscene_ChemicalDrop, CPZ1Intro_Cutscene_PlayerChemicalReact, CPZ1Intro_Cutscene_ReadyStage,
+                              StateMachine_None);
+
+#if MANIA_USE_PLUS
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
+#endif
 }
 
 void CPZ1Intro_Particle_ChemDrop(EntityDebris *debris)

--- a/SonicMania/Objects/CPZ/CPZ1Intro.c
+++ b/SonicMania/Objects/CPZ/CPZ1Intro.c
@@ -25,7 +25,7 @@ void CPZ1Intro_Update(void)
                                       StateMachine_None);
 
 #if MANIA_USE_PLUS
-            CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+            CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
         }
     }

--- a/SonicMania/Objects/CPZ/CPZ1Intro.h
+++ b/SonicMania/Objects/CPZ/CPZ1Intro.h
@@ -38,6 +38,7 @@ void CPZ1Intro_EditorLoad(void);
 void CPZ1Intro_Serialize(void);
 
 // Extra Entity Functions
+void CPZ1Intro_SetupCutscene(void);
 void CPZ1Intro_Particle_ChemDrop(EntityDebris *debris);
 void CPZ1Intro_HandleRubyHover(EntityCutsceneSeq *cutsceneSequence, EntityPlayer *player1, EntityPlayer *player2, int32 targetY);
 

--- a/SonicMania/Objects/CPZ/CPZ2Outro.c
+++ b/SonicMania/Objects/CPZ/CPZ2Outro.c
@@ -51,7 +51,7 @@ void CPZ2Outro_SetupCutscene(void)
     CutsceneSeq_StartSequence(self, CPZ2Outro_Cutscene_Outro, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     HUD_MoveOut();

--- a/SonicMania/Objects/Credits/EncoreGoodEnd.c
+++ b/SonicMania/Objects/Credits/EncoreGoodEnd.c
@@ -22,7 +22,7 @@ void EncoreGoodEnd_Update(void)
                                           EncoreGoodEnd_Cutscene_ClinkGlasses, EncoreGoodEnd_Cutscene_KingAppear,
                                           EncoreGoodEnd_Cutscene_ThanksForPlaying, EncoreGoodEnd_Cutscene_FinishCutscene, StateMachine_None);
 #if MANIA_USE_PLUS
-                CutsceneSeq_SetSkipType(SKIPTYPE_CALLBACK, EncoreGoodEnd_Cutscene_SkipCB);
+                CutsceneSeq_SetSkipTypeCallback(EncoreGoodEnd_Cutscene_SkipCB);
 #endif
 
                 self->activated = true;

--- a/SonicMania/Objects/Cutscene/CutsceneSeq.c
+++ b/SonicMania/Objects/Cutscene/CutsceneSeq.c
@@ -113,11 +113,19 @@ void CutsceneSeq_NewState(int32 nextState, EntityCutsceneSeq *seq)
     }
 }
 #if MANIA_USE_PLUS
-void CutsceneSeq_SetSkipType(uint8 type, void (*callback)(void))
+void CutsceneSeq_SetSkipType(uint8 type)
 {
     EntityCutsceneSeq *seq = RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq);
     if (seq->classID) {
-        seq->skipType     = type;
+        seq->skipType = type;
+    }
+}
+
+void CutsceneSeq_SetSkipTypeCallback(void (*callback)(void))
+{
+    EntityCutsceneSeq *seq = RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq);
+    if (seq->classID) {
+        seq->skipType     = SKIPTYPE_CALLBACK;
         seq->skipCallback = callback;
     }
 }

--- a/SonicMania/Objects/Cutscene/CutsceneSeq.h
+++ b/SonicMania/Objects/Cutscene/CutsceneSeq.h
@@ -60,8 +60,10 @@ void CutsceneSeq_Serialize(void);
 // Initializes a new state with ID of `nextState`
 void CutsceneSeq_NewState(int32 nextState, EntityCutsceneSeq *seq);
 #if MANIA_USE_PLUS
-// Sets the cutscene's skip type (and callback if applicable)
-void CutsceneSeq_SetSkipType(uint8 type, void (*callback)(void));
+// Sets the cutscene's skip type (non-callback)
+void CutsceneSeq_SetSkipType(uint8 type);
+// Sets the cutscene's skip type to SKIPTYPE_CALLBACK and set the callback function
+void CutsceneSeq_SetSkipTypeCallback(void (*callback)(void));
 // Checks if the cutscene was skipped
 void CutsceneSeq_CheckSkip(uint8 skipType, EntityCutsceneSeq *seq, void (*skipCallback)(void));
 #endif

--- a/SonicMania/Objects/ERZ/ERZOutro.c
+++ b/SonicMania/Objects/ERZ/ERZOutro.c
@@ -19,7 +19,7 @@ void ERZOutro_Update(void)
                                   ERZOutro_Cutscene_ShowEnding, StateMachine_None);
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+        CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 
         self->activated = true;

--- a/SonicMania/Objects/ERZ/ERZStart.c
+++ b/SonicMania/Objects/ERZ/ERZStart.c
@@ -25,7 +25,7 @@ void ERZStart_Update(void)
                                           ERZStart_Cutscene_Fight, StateMachine_None);
 
 #if MANIA_USE_PLUS
-                CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+                CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 
                 self->activated = true;

--- a/SonicMania/Objects/FBZ/FBZ1Outro.c
+++ b/SonicMania/Objects/FBZ/FBZ1Outro.c
@@ -75,7 +75,7 @@ void FBZ1Outro_StartCutscene(void)
                               FBZ1Outro_Cutscene_PrepareFBZ2, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 }
 

--- a/SonicMania/Objects/FBZ/FBZ1Outro.c
+++ b/SonicMania/Objects/FBZ/FBZ1Outro.c
@@ -75,7 +75,7 @@ void FBZ1Outro_StartCutscene(void)
                               FBZ1Outro_Cutscene_PrepareFBZ2, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 }
 

--- a/SonicMania/Objects/FBZ/FBZ2Outro.c
+++ b/SonicMania/Objects/FBZ/FBZ2Outro.c
@@ -40,7 +40,7 @@ void FBZ2Outro_StartCutscene(EntityFBZ2Outro *outro)
                               StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     HUD_MoveOut();

--- a/SonicMania/Objects/GHZ/GHZ2Outro.c
+++ b/SonicMania/Objects/GHZ/GHZ2Outro.c
@@ -19,7 +19,7 @@ void GHZ2Outro_Update(void)
                                   GHZ2Outro_Cutscene_LoadCPZ1, StateMachine_None);
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_CALLBACK, GHZ2Outro_Cutscene_SkipCB);
+        CutsceneSeq_SetSkipTypeCallback(GHZ2Outro_Cutscene_SkipCB);
 #endif
 
         self->active = ACTIVE_NEVER;
@@ -28,7 +28,7 @@ void GHZ2Outro_Update(void)
         CutsceneSeq_StartSequence(self, GHZ2Outro_Cutscene_FinishActClear, GHZ2Outro_Cutscene_JumpIntoHole, StateMachine_None);
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
         HUD_MoveOut();

--- a/SonicMania/Objects/GHZ/GHZCutsceneK.c
+++ b/SonicMania/Objects/GHZ/GHZCutsceneK.c
@@ -22,7 +22,7 @@ void GHZCutsceneK_Update(void)
                 CutsceneSeq_StartSequence(self, GHZCutsceneK_Cutscene_None, StateMachine_None);
 
 #if MANIA_USE_PLUS
-                CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+                CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 
                 self->activated = true;

--- a/SonicMania/Objects/GHZ/GHZCutsceneST.c
+++ b/SonicMania/Objects/GHZ/GHZCutsceneST.c
@@ -26,7 +26,7 @@ void GHZCutsceneST_Update(void)
                                           GHZCutsceneST_Cutscene_SetupGHZ1, StateMachine_None);
 
 #if MANIA_USE_PLUS
-                CutsceneSeq_SetSkipType(SKIPTYPE_CALLBACK, GHZCutsceneST_Cutscene_SkipCB);
+                CutsceneSeq_SetSkipTypeCallback(GHZCutsceneST_Cutscene_SkipCB);
 #endif
 
                 self->activated = true;

--- a/SonicMania/Objects/HCZ/HCZ1Intro.c
+++ b/SonicMania/Objects/HCZ/HCZ1Intro.c
@@ -22,7 +22,7 @@ void HCZ1Intro_Update(void)
             CutsceneSeq_StartSequence(self, HCZ1Intro_Cutscene_Intro, StateMachine_None);
 
 #if MANIA_USE_PLUS
-            CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+            CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
         }
     }

--- a/SonicMania/Objects/LRZ/LRZ1Outro.c
+++ b/SonicMania/Objects/LRZ/LRZ1Outro.c
@@ -46,7 +46,7 @@ void LRZ1Outro_StartCutscene(void)
     }
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     for (int32 i = 0; i < 0x100; ++i) RSDK.SetPaletteEntry(5, i, 0x000000);

--- a/SonicMania/Objects/LRZ/LRZ3Cutscene.c
+++ b/SonicMania/Objects/LRZ/LRZ3Cutscene.c
@@ -18,7 +18,7 @@ void LRZ3Cutscene_Update(void)
     CutsceneSeq_StartSequence(self, LRZ3Cutscene_Cutscene_FadeIn, LRZ3Cutscene_Cutscene_RunRight, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 
     self->active = ACTIVE_NEVER;

--- a/SonicMania/Objects/LRZ/LRZ3Outro.c
+++ b/SonicMania/Objects/LRZ/LRZ3Outro.c
@@ -184,7 +184,10 @@ void LRZ3Outro_StageFinish_EndAct2ST(void)
 
 bool32 LRZ3Outro_Cutscene_StopPlayers(EntityCutsceneSeq *host)
 {
-    foreach_active(Player, player) { player->state = Player_State_Static; }
+    foreach_active(Player, player) {
+        player->state = Player_State_Static;
+        player->stateInput = StateMachine_None;
+    }
 
     return true;
 }

--- a/SonicMania/Objects/LRZ/LRZ3Outro.c
+++ b/SonicMania/Objects/LRZ/LRZ3Outro.c
@@ -174,7 +174,7 @@ void LRZ3Outro_StageFinish_EndAct2ST(void)
         CutsceneSeq_StartSequence(cutscene, LRZ3Outro_Cutscene_StopPlayers, LRZ3Outro_Cutscene_LightUpLittlePlanet, StateMachine_None);
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
         HUD_MoveOut();

--- a/SonicMania/Objects/LRZ/LRZ3OutroK.c
+++ b/SonicMania/Objects/LRZ/LRZ3OutroK.c
@@ -66,7 +66,7 @@ void LRZ3OutroK_StartCutscene(void)
                               LRZ3OutroK_Cutscene_TeleporterActivated, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     HUD_MoveOut();

--- a/SonicMania/Objects/MMZ/MMZ2Outro.c
+++ b/SonicMania/Objects/MMZ/MMZ2Outro.c
@@ -47,7 +47,7 @@ void MMZ2Outro_StartCutscene(void)
                               StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     RSDK.CopyPalette(0, 1, 1, 1, 0xFF);

--- a/SonicMania/Objects/MSZ/MSZ1KIntro.c
+++ b/SonicMania/Objects/MSZ/MSZ1KIntro.c
@@ -23,7 +23,7 @@ void MSZ1KIntro_Update(void)
                                       StateMachine_None);
 
 #if MANIA_USE_PLUS
-            CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+            CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
         }
     }

--- a/SonicMania/Objects/MSZ/MSZ2Cutscene.c
+++ b/SonicMania/Objects/MSZ/MSZ2Cutscene.c
@@ -60,7 +60,7 @@ void MSZ2Cutscene_SetupCutscene(void)
                               MSZ2Cutscene_Cutscene_AppearInBG, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     HUD_MoveOut();

--- a/SonicMania/Objects/MSZ/MSZ2Cutscene.c
+++ b/SonicMania/Objects/MSZ/MSZ2Cutscene.c
@@ -91,8 +91,8 @@ bool32 MSZ2Cutscene_Cutscene_GoToPistol(EntityCutsceneSeq *host)
         MSZ2Cutscene_GetPistolPtr();
         parallaxSprite->visible = true;
         parallaxSprite->drawFX  = FX_SCALE;
-        parallaxSprite->scale.x = 0x200;
-        parallaxSprite->scale.y = 0x200;
+        parallaxSprite->scale.x = 0x100;
+        parallaxSprite->scale.y = 0x100;
         prison->notSolid        = true;
 
         Vector2 size;

--- a/SonicMania/Objects/MSZ/MSZCutsceneK.c
+++ b/SonicMania/Objects/MSZ/MSZCutsceneK.c
@@ -72,7 +72,7 @@ void MSZCutsceneK_StartCutscene(void)
     CutsceneSeq_StartSequence(self, MSZCutsceneK_Cutscene_RidingTornado, MSZCutsceneK_Cutscene_KnockedOffTornado, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_CALLBACK, MSZCutsceneK_Cutscene_SkipCB);
+    CutsceneSeq_SetSkipTypeCallback(MSZCutsceneK_Cutscene_SkipCB);
 #endif
 }
 

--- a/SonicMania/Objects/MSZ/MSZCutsceneST.c
+++ b/SonicMania/Objects/MSZ/MSZCutsceneST.c
@@ -101,7 +101,7 @@ void MSZCutsceneST_SetupCutscene(void)
                               MSZCutsceneST_Cutscene_SetupMSZ2, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 }
 

--- a/SonicMania/Objects/MSZ/MSZCutsceneST.c
+++ b/SonicMania/Objects/MSZ/MSZCutsceneST.c
@@ -163,8 +163,7 @@ bool32 MSZCutsceneST_Cutscene_AwaitActFinish(EntityCutsceneSeq *host)
         }
 
 #if MANIA_USE_PLUS
-        if (RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq)->classID)
-            RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq)->skipType = SKIPTYPE_NEXTSCENE;
+        CutsceneSeq_SetSkipType(SKIPTYPE_NEXTSCENE);
 #endif
         return true;
     }

--- a/SonicMania/Objects/OOZ/OOZ1Outro.c
+++ b/SonicMania/Objects/OOZ/OOZ1Outro.c
@@ -19,7 +19,7 @@ void OOZ1Outro_Update(void)
                                   OOZ1Outro_Cutscene_BeginAct, StateMachine_None);
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+        CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
     }
 

--- a/SonicMania/Objects/OOZ/OOZ1Outro.c
+++ b/SonicMania/Objects/OOZ/OOZ1Outro.c
@@ -129,8 +129,7 @@ bool32 OOZ1Outro_Cutscene_PostActClearSetup(EntityCutsceneSeq *host)
         Zone->cameraBoundsB[0] = self->boundsB;
 
 #if MANIA_USE_PLUS
-        if (RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq)->classID)
-            RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq)->skipType = SKIPTYPE_RELOADSCN;
+        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
         return true;
     }

--- a/SonicMania/Objects/OOZ/OOZ2Outro.c
+++ b/SonicMania/Objects/OOZ/OOZ2Outro.c
@@ -113,7 +113,7 @@ void OOZ2Outro_State_SubFloat(void)
 
 void OOZ2Outro_CheckSkip(void)
 {
-    if (ControllerInfo->keyStart.press && !(SceneInfo->state & ENGINESTATE_REGULAR)) {
+    if (ControllerInfo->keyStart.press && (SceneInfo->state & ENGINESTATE_REGULAR)) {
         globals->suppressTitlecard = false;
         globals->suppressAutoMusic = false;
         globals->enableIntro       = false;

--- a/SonicMania/Objects/PGZ/PSZ1Intro.c
+++ b/SonicMania/Objects/PGZ/PSZ1Intro.c
@@ -18,7 +18,7 @@ void PSZ1Intro_Update(void)
                               StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 
     self->active = ACTIVE_NEVER;

--- a/SonicMania/Objects/PGZ/PSZ2Intro.c
+++ b/SonicMania/Objects/PGZ/PSZ2Intro.c
@@ -19,7 +19,7 @@ void PSZ2Intro_Update(void)
                               PSZ2Intro_Cutscene_JogIntoPlace, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 
     self->active = ACTIVE_NEVER;

--- a/SonicMania/Objects/PGZ/PSZ2Intro.c
+++ b/SonicMania/Objects/PGZ/PSZ2Intro.c
@@ -101,8 +101,7 @@ bool32 PSZ2Intro_Cutscene_ShowActClear(EntityCutsceneSeq *host)
 {
     if (ActClear->finished) {
 #if MANIA_USE_PLUS
-        if (RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq)->classID)
-            RSDK_GET_ENTITY(SLOT_CUTSCENESEQ, CutsceneSeq)->skipType = SKIPTYPE_RELOADSCN;
+        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
         return true;

--- a/SonicMania/Objects/PGZ/PSZ2Outro.c
+++ b/SonicMania/Objects/PGZ/PSZ2Outro.c
@@ -18,7 +18,7 @@ void PSZ2Outro_Update(void)
                               PSZ2Outro_Cutscene_LoadSSZ1, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     HUD_MoveOut();

--- a/SonicMania/Objects/SPZ/SPZ1Intro.c
+++ b/SonicMania/Objects/SPZ/SPZ1Intro.c
@@ -19,7 +19,7 @@ void SPZ1Intro_Update(void)
         }
         else {
             self->activated = true;
-            CutsceneSeq_StartSequence(self, SPZ1Intro_Cutscene_SetupAct, SPZ1Intro_Cutscene_ExitPipe, SPZ1Intro_Cutscene_BeginAct1, NULL);
+            CutsceneSeq_StartSequence(self, SPZ1Intro_Cutscene_SetupAct, SPZ1Intro_Cutscene_ExitPipe, SPZ1Intro_Cutscene_BeginAct1, StateMachine_None);
 
 #if MANIA_USE_PLUS
             CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);

--- a/SonicMania/Objects/SPZ/SPZ1Intro.c
+++ b/SonicMania/Objects/SPZ/SPZ1Intro.c
@@ -22,7 +22,7 @@ void SPZ1Intro_Update(void)
             CutsceneSeq_StartSequence(self, SPZ1Intro_Cutscene_SetupAct, SPZ1Intro_Cutscene_ExitPipe, SPZ1Intro_Cutscene_BeginAct1, NULL);
 
 #if MANIA_USE_PLUS
-            CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+            CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
         }
     }

--- a/SonicMania/Objects/SPZ/SPZ2Outro.c
+++ b/SonicMania/Objects/SPZ/SPZ2Outro.c
@@ -61,7 +61,7 @@ void SPZ2Outro_StartCutscene(void)
                               SPZ2Outro_Cutscene_FBZFlyAway, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     HUD_MoveOut();

--- a/SonicMania/Objects/SSZ/SSZ1Intro.c
+++ b/SonicMania/Objects/SSZ/SSZ1Intro.c
@@ -51,7 +51,7 @@ void SSZ1Intro_SetupCutscene(void)
                               StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 }
 

--- a/SonicMania/Objects/SSZ/SSZ1Intro.c
+++ b/SonicMania/Objects/SSZ/SSZ1Intro.c
@@ -19,12 +19,7 @@ void SSZ1Intro_Update(void)
         }
         else {
             self->activated = true;
-            CutsceneSeq_StartSequence(self, SSZ1Intro_Cutscene_FinishRubyWarp, SSZ1Intro_Cutscene_HandeLanding, SSZ1Intro_Cutscene_BeginAct1,
-                                      StateMachine_None);
-
-#if MANIA_USE_PLUS
-            CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
-#endif
+            SSZ1Intro_SetupCutscene();
         }
     }
 }
@@ -47,6 +42,17 @@ void SSZ1Intro_Create(void *data)
 void SSZ1Intro_StageLoad(void)
 {
     foreach_all(FXRuby, ruby) { SSZ1Intro->fxRuby = ruby; }
+}
+
+void SSZ1Intro_SetupCutscene(void)
+{
+    RSDK_THIS(SSZ1Intro);
+    CutsceneSeq_StartSequence(self, SSZ1Intro_Cutscene_FinishRubyWarp, SSZ1Intro_Cutscene_HandleLanding, SSZ1Intro_Cutscene_BeginAct1,
+                              StateMachine_None);
+
+#if MANIA_USE_PLUS
+    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
+#endif
 }
 
 void SSZ1Intro_HandleRubyHover(EntityCutsceneSeq *host, EntityPlayer *player1, EntityPlayer *player2, int32 offset)
@@ -120,7 +126,7 @@ bool32 SSZ1Intro_Cutscene_FinishRubyWarp(EntityCutsceneSeq *host)
     }
     return false;
 }
-bool32 SSZ1Intro_Cutscene_HandeLanding(EntityCutsceneSeq *host)
+bool32 SSZ1Intro_Cutscene_HandleLanding(EntityCutsceneSeq *host)
 {
     MANIA_GET_PLAYER(player1, player2, camera);
     UNUSED(camera);

--- a/SonicMania/Objects/SSZ/SSZ1Intro.c
+++ b/SonicMania/Objects/SSZ/SSZ1Intro.c
@@ -23,7 +23,7 @@ void SSZ1Intro_Update(void)
                                       StateMachine_None);
 
 #if MANIA_USE_PLUS
-            CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+            CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
         }
     }

--- a/SonicMania/Objects/SSZ/SSZ1Intro.h
+++ b/SonicMania/Objects/SSZ/SSZ1Intro.h
@@ -31,10 +31,11 @@ void SSZ1Intro_EditorLoad(void);
 void SSZ1Intro_Serialize(void);
 
 // Extra Entity Functions
+void SSZ1Intro_SetupCutscene(void);
 void SSZ1Intro_HandleRubyHover(EntityCutsceneSeq *host, EntityPlayer *player1, EntityPlayer *player2, int32 offset);
 
 bool32 SSZ1Intro_Cutscene_FinishRubyWarp(EntityCutsceneSeq *host);
-bool32 SSZ1Intro_Cutscene_HandeLanding(EntityCutsceneSeq *host);
+bool32 SSZ1Intro_Cutscene_HandleLanding(EntityCutsceneSeq *host);
 bool32 SSZ1Intro_Cutscene_BeginAct1(EntityCutsceneSeq *host);
 
 #endif //! OBJ_SSZ1INTRO_H

--- a/SonicMania/Objects/SSZ/SSZ1Outro.c
+++ b/SonicMania/Objects/SSZ/SSZ1Outro.c
@@ -19,7 +19,7 @@ void SSZ1Outro_Update(void)
         CutsceneSeq_StartSequence(self, SSZ1Outro_Cutscene_TimeWarpRunway, SSZ1Outro_Cutscene_TimeWarp, StateMachine_None);
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
     }
 }

--- a/SonicMania/Objects/SSZ/SSZ3Cutscene.c
+++ b/SonicMania/Objects/SSZ/SSZ3Cutscene.c
@@ -20,7 +20,7 @@ void SSZ3Cutscene_Update(void)
                                   SSZ3Cutscene_CutsceneOutro_LoadHCZ1, StateMachine_None);
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+        CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
         HUD_MoveOut();
@@ -32,7 +32,7 @@ void SSZ3Cutscene_Update(void)
         CutsceneSeq_StartSequence(self, SSZ3Cutscene_CutsceneIntro_EnterStageLeft, SSZ3Cutscene_CutsceneIntro_PlayerRunLeft, StateMachine_None);
 
 #if MANIA_USE_PLUS
-        CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+        CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 
         self->active = ACTIVE_NEVER;

--- a/SonicMania/Objects/SSZ/TTCutscene.c
+++ b/SonicMania/Objects/SSZ/TTCutscene.c
@@ -53,7 +53,7 @@ void TTCutscene_StartCutscene(void)
                               TTCutscene_Cutscene_NextScene, StateMachine_None);
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_CALLBACK, TTCutscene_Cutscene_SkipCB);
+    CutsceneSeq_SetSkipTypeCallback(TTCutscene_Cutscene_SkipCB);
 #endif
 }
 

--- a/SonicMania/Objects/TMZ/TMZ1Outro.c
+++ b/SonicMania/Objects/TMZ/TMZ1Outro.c
@@ -23,7 +23,7 @@ void TMZ1Outro_Update(void)
     }
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_RELOADSCN);
 #endif
 
     self->active = ACTIVE_NEVER;

--- a/SonicMania/Objects/TMZ/TMZ2Outro.c
+++ b/SonicMania/Objects/TMZ/TMZ2Outro.c
@@ -75,7 +75,7 @@ void TMZ2Outro_SetupCutscene(void)
 #endif
 
 #if MANIA_USE_PLUS
-    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED, StateMachine_None);
+    CutsceneSeq_SetSkipType(SKIPTYPE_DISABLED);
 #endif
 }
 

--- a/SonicMania/PublicFunctions.c
+++ b/SonicMania/PublicFunctions.c
@@ -470,6 +470,7 @@ void InitPublicFunctions()
     ADD_PUBLIC_FUNC(ChemicalPool_State_Changing);
 
     // CPZ/CPZ1Intro
+    ADD_PUBLIC_FUNC(CPZ1Intro_SetupCutscene);
     ADD_PUBLIC_FUNC(CPZ1Intro_Particle_ChemDrop);
     ADD_PUBLIC_FUNC(CPZ1Intro_HandleRubyHover);
     ADD_PUBLIC_FUNC(CPZ1Intro_CheckSonicAnimFinish);
@@ -6047,9 +6048,10 @@ void InitPublicFunctions()
     ADD_PUBLIC_FUNC(SpikeFlail_GetScale);
 
     // SSZ/SSZ1Intro
+    ADD_PUBLIC_FUNC(SSZ1Intro_SetupCutscene);
     ADD_PUBLIC_FUNC(SSZ1Intro_HandleRubyHover);
     ADD_PUBLIC_FUNC(SSZ1Intro_Cutscene_FinishRubyWarp);
-    ADD_PUBLIC_FUNC(SSZ1Intro_Cutscene_HandeLanding);
+    ADD_PUBLIC_FUNC(SSZ1Intro_Cutscene_HandleLanding);
     ADD_PUBLIC_FUNC(SSZ1Intro_Cutscene_BeginAct1);
 
     // SSZ/SSZ1Outro

--- a/SonicMania/PublicFunctions.c
+++ b/SonicMania/PublicFunctions.c
@@ -709,6 +709,8 @@ void InitPublicFunctions()
     ADD_PUBLIC_FUNC(CutsceneSeq_NewState);
 #if MANIA_USE_PLUS
     ADD_PUBLIC_FUNC(CutsceneSeq_CheckSkip);
+    ADD_PUBLIC_FUNC(CutsceneSeq_SetSkipType);
+    ADD_PUBLIC_FUNC(CutsceneSeq_SetSkipTypeCallback);
 #endif
     ADD_PUBLIC_FUNC(CutsceneSeq_GetEntity);
     ADD_PUBLIC_FUNC(CutsceneSeq_LockPlayerControl);


### PR DESCRIPTION
In the original code, cutscene objects do not set the `skipCallback` field unless when using `SKIPTYPE_CALLBACK`.
Make `CutsceneSeq_SetSkipType` only set the skip type (for non-callback skips), and introduce a new `CutsceneSeq_SetSkipTypeCallback` which sets the skip type as `SKIPTYPE_CALLBACK` and only takes the callback function as parameter.
Enforce usage of these functions everywhere in the code.
Also add them in the public function list so they can be used in mods.

Add `{CPZ1Intro/SSZ1Intro}_SetupCutscene` functions that are in the original (Steam) but weren't in the decomp.


Also fixes #214, along with multiple inaccuracies:
* `MSZ2Cutscene`: Fix parallax sprite scale being too big
* `LRZ3Outro`: Fix missing player->stateInput reset
* `SSZ1Intro`: Fix incorrect skip type