### PR TITLE
Math: Fix Sqrt helper and use Distance helper where appropriate

### DIFF
--- a/SonicMania/Objects/ERZ/ERZOutro.c
+++ b/SonicMania/Objects/ERZ/ERZOutro.c
@@ -363,9 +363,7 @@ bool32 ERZOutro_Cutscene_EnterPortal(EntityCutsceneSeq *host)
         ERZOutro->rubyPortalAcceleration = 0;
 
         host->storedTimer = RSDK.ATan2(player1->position.x - portal->position.x, player1->position.y - portal->position.y) << 16;
-        int32 rx          = abs(portal->position.x - player1->position.x) >> 16;
-        int32 ry          = abs(portal->position.y - player1->position.y) >> 16;
-        host->storedValue = MathHelpers_SquareRoot(rx * rx + ry * ry) << 16;
+        host->storedValue = MathHelpers_Distance(player1->position.x, player1->position.y, portal->position.x, portal->position.y);
 
         player1->drawFX |= FX_SCALE;
         player1->scale.x = 0x200;
@@ -386,9 +384,7 @@ bool32 ERZOutro_Cutscene_EnterPortal(EntityCutsceneSeq *host)
             ruby->startPos.y = ruby->position.y;
 
             ERZOutro->rubyPortalAngle  = RSDK.ATan2(ruby->position.x - portal->position.x, ruby->position.y - portal->position.y) << 16;
-            int32 rx                   = abs(portal->position.x - ruby->position.x) >> 16;
-            int32 ry                   = abs(portal->position.y - ruby->position.y) >> 16;
-            ERZOutro->rubyPortalRadius = MathHelpers_SquareRoot(rx * rx + ry * ry) << 16;
+            ERZOutro->rubyPortalRadius = MathHelpers_Distance(ruby->position.x, ruby->position.y, portal->position.x, portal->position.y);
 
             ruby->drawFX |= FX_SCALE;
             ruby->scale.x = 0x200;

--- a/SonicMania/Objects/HCZ/PullChain.c
+++ b/SonicMania/Objects/HCZ/PullChain.c
@@ -49,10 +49,10 @@ void PullChain_Update(void)
             if (!((1 << playerID) & self->activePlayers)) {
                 if (!(self->releasedPlayers & (1 << playerID))) {
                     if (!Current || !((1 << playerID) & Current->activePlayers)) {
-                        int32 x = abs(player->position.x - self->position.x);
-                        int32 y = abs((player->position.y - 0x180000) - self->position.y);
+                        int32 x = abs(player->position.x - self->position.x) >> 16;
+                        int32 y = abs((player->position.y - 0x180000) - self->position.y) >> 16;
 
-                        if (MathHelpers_SquareRoot((x >> 16) * (x >> 16) + (y >> 16) * (y >> 16)) <= 8 && player->state != Player_State_Static
+                        if (MathHelpers_SquareRoot(x * x + y * y) <= 8 && player->state != Player_State_Static
                             && !self->grabDelay[playerID]) {
                             self->activePlayers |= 1 << playerID;
                             self->releasedPlayers |= 1 << playerID;

--- a/SonicMania/Objects/Helpers/MathHelpers.c
+++ b/SonicMania/Objects/Helpers/MathHelpers.c
@@ -123,7 +123,7 @@ Vector2 MathHelpers_GetBezierPoint(int32 percent, int32 x1, int32 y1, int32 x2, 
 int32 MathHelpers_SquareRoot(uint32 num)
 {
     int32 rem = 1 << 30; // 1 << 31 would result in the value having to be unsigned, so this is the max
-    while (rem > (int32)num) rem >>= 2;
+    while (rem > num) rem >>= 2;
 
     uint32 root = 0;
     while (rem) {
@@ -141,10 +141,10 @@ int32 MathHelpers_SquareRoot(uint32 num)
 
 int32 MathHelpers_Distance(int32 x1, int32 y1, int32 x2, int32 y2)
 {
-    int32 distanceX = abs(x2 - x1);
-    int32 distanceY = abs(y2 - y1);
+    int32 distanceX = abs(x2 - x1) >> 16;
+    int32 distanceY = abs(y2 - y1) >> 16;
 
-    return MathHelpers_SquareRoot((distanceX >> 16) * (distanceX >> 16) + (distanceY >> 16) * (distanceY >> 16)) << 16;
+    return (MathHelpers_SquareRoot(distanceX * distanceX + distanceY * distanceY) << 16);
 }
 
 int32 MathHelpers_GetBezierCurveLength(int32 x1, int32 y1, int32 x2, int32 y2, int32 x3, int32 y3, int32 x4, int32 y4)

--- a/SonicMania/Objects/LRZ/WalkerLegs.c
+++ b/SonicMania/Objects/LRZ/WalkerLegs.c
@@ -276,10 +276,10 @@ void WalkerLegs_CheckTileCollisions(void)
         y = self->legPos[1].y;
     }
 
-    int32 rx = abs(self->legPos[1].x - self->legPos[0].x);
-    int32 ry = abs(self->legPos[1].y - self->legPos[0].y);
+    int32 rx = abs(self->legPos[1].x - self->legPos[0].x) >> 16;
+    int32 ry = abs(self->legPos[1].y - self->legPos[0].y) >> 16;
 
-    uint16 radius = MathHelpers_SquareRoot((rx >> 16) * (rx >> 16) + (ry >> 16) * (ry >> 16)) - 1;
+    uint16 radius = MathHelpers_SquareRoot(rx * rx + ry * ry) - 1;
     if (radius <= 0x40)
         radius = 0x40;
 

--- a/SonicMania/Objects/PGZ/PaperRoller.c
+++ b/SonicMania/Objects/PGZ/PaperRoller.c
@@ -299,9 +299,9 @@ void PaperRoller_HandleRollerCollisions(void)
     {
         int32 playerID = RSDK.GetEntitySlot(player);
         if (self->playerTimer[playerID] <= 0) {
-            int32 distX = abs(self->position.x - player->position.x);
-            int32 distY = abs(self->position.y - player->position.y);
-            if (MathHelpers_SquareRoot((distX >> 16) * (distX >> 16) + (distY >> 16) * (distY >> 16)) <= 40 && !self->playerTimer[playerID]) {
+            int32 distX = abs(self->position.x - player->position.x) >> 16;
+            int32 distY = abs(self->position.y - player->position.y) >> 16;
+            if (MathHelpers_SquareRoot(distX * distX + distY * distY) <= 40 && !self->playerTimer[playerID]) {
                 RSDK.PlaySfx(Player->sfxRelease, false, 255);
                 int32 angle = RSDK.ATan2(player->position.x - self->position.x, player->position.y - self->position.y);
 


### PR DESCRIPTION
The square root computation ignores negative integers by simply dealing with it as an unsigned value.

Multiple parts of the code weren't using MathHelpers_Distance at all and were instead manually computing the distance. Refactor these computations to clean things up.

Fixes #225.