### PR TITLE
ERZStart/PhantomKing: Fix missing sprite animation and ruby offset

### DIFF
--- a/SonicMania/Objects/ERZ/ERZStart.c
+++ b/SonicMania/Objects/ERZ/ERZStart.c
@@ -18,7 +18,7 @@ void ERZStart_Update(void)
         {
             if (!player->sidekick && Player_CheckCollisionTouch(player, self, &self->hitbox)) {
                 CutsceneSeq_StartSequence(self, ERZStart_Cutscene_FadeIn, ERZStart_Cutscene_ShrinkRubyWarpFX, ERZStart_Cutscene_EnterKing,
-                                          ERZStart_Cutscene_KingMovingRuby, ERZStart_Cutscene_KingAttatchHornRuby,
+                                          ERZStart_Cutscene_KingMovingRuby, ERZStart_Cutscene_KingAttachHornRuby,
                                           ERZStart_Cutscene_SetupEggmanReveal, ERZStart_Cutscene_EnterEggman, ERZStart_Cutscene_EggmanKingWrestling,
                                           ERZStart_Cutscene_PostWrestleFadeIn, ERZStart_Cutscene_ReturnCamToSonic,
                                           ERZStart_Cutscene_PreparePlayerTransform, ERZStart_Cutscene_PlayerTransform, ERZStart_Cutscene_StartFight,
@@ -113,7 +113,7 @@ void ERZStart_SetupObjects(void)
     }
 }
 
-void ERZStart_HandlePlayerHover(EntityCutsceneSeq *seq, EntityPlayer *player, int32 posY)
+void ERZStart_HandlePlayerHover(EntityPlayer *player, EntityCutsceneSeq *seq, int32 posY)
 {
     RSDK.SetSpriteAnimation(player->aniFrames, ANI_FAN, &player->animator, false, 0);
     player->position.x = 0x300000;
@@ -188,7 +188,7 @@ bool32 ERZStart_Cutscene_FadeIn(EntityCutsceneSeq *host)
         }
     }
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
     return false;
 }
 
@@ -201,19 +201,18 @@ bool32 ERZStart_Cutscene_ShrinkRubyWarpFX(EntityCutsceneSeq *host)
     EntityPhantomRuby *ruby = ERZStart->ruby;
     EntityFXRuby *fxRuby    = ERZStart->fxRuby;
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
-
     if (!host->timer)
         fxRuby->state = FXRuby_State_Shrinking;
 
     EntityPhantomKing *king = ERZStart->king;
     if (fxRuby->outerRadius <= 0) {
-        ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+        ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
         ruby->drawGroup = Zone->objectDrawGroup[0] + 1;
         king->state     = PhantomKing_State_SetupArms;
         return true;
     }
 
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
     return false;
 }
 
@@ -225,7 +224,7 @@ bool32 ERZStart_Cutscene_EnterKing(EntityCutsceneSeq *host)
 
     EntityPhantomRuby *ruby = ERZStart->ruby;
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
 
     EntityPhantomKing *king = ERZStart->king;
     if (king->state == PhantomKing_State_TakeRubyAway) {
@@ -243,7 +242,7 @@ bool32 ERZStart_Cutscene_KingMovingRuby(EntityCutsceneSeq *host)
 
     EntityPhantomRuby *ruby = ERZStart->ruby;
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
 
     EntityPhantomKing *king = ERZStart->king;
     if (!host->timer) {
@@ -269,7 +268,7 @@ bool32 ERZStart_Cutscene_KingMovingRuby(EntityCutsceneSeq *host)
     return false;
 }
 
-bool32 ERZStart_Cutscene_KingAttatchHornRuby(EntityCutsceneSeq *host)
+bool32 ERZStart_Cutscene_KingAttachHornRuby(EntityCutsceneSeq *host)
 {
     MANIA_GET_PLAYER(player1, player2, camera);
     UNUSED(player2);
@@ -277,7 +276,7 @@ bool32 ERZStart_Cutscene_KingAttatchHornRuby(EntityCutsceneSeq *host)
 
     EntityPhantomRuby *ruby = ERZStart->ruby;
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
     EntityPhantomKing *king = ERZStart->king;
 
     if (!host->timer) {
@@ -316,7 +315,7 @@ bool32 ERZStart_Cutscene_SetupEggmanReveal(EntityCutsceneSeq *host)
 
     EntityPhantomRuby *ruby = ERZStart->ruby;
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
 
     if (host->timer == 30)
         Camera_SetupLerp(CAMERA_LERP_NORMAL, 0, camera->position.x - (ScreenInfo->size.x << 16), camera->position.y, 3);
@@ -334,7 +333,7 @@ bool32 ERZStart_Cutscene_EnterEggman(EntityCutsceneSeq *host)
 
     EntityPhantomRuby *ruby = ERZStart->ruby;
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
 
     EntityKleptoMobile *eggman = ERZStart->eggman;
     EntityPhantomKing *king    = ERZStart->king;
@@ -456,7 +455,7 @@ bool32 ERZStart_Cutscene_EggmanKingWrestling(EntityCutsceneSeq *host)
     EntityPhantomKing *kingChild1 = RSDK_GET_ENTITY(kingSlot - 1, PhantomKing);
     EntityPhantomKing *kingChild2 = RSDK_GET_ENTITY(kingSlot + 1, PhantomKing);
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
 
     if (host->timer > 6 && !(host->timer % 6))
         Camera_ShakeScreen(0, 1, 0);
@@ -509,7 +508,7 @@ bool32 ERZStart_Cutscene_PostWrestleFadeIn(EntityCutsceneSeq *host)
     EntityPhantomKing *kingArmL = RSDK_GET_ENTITY(kingSlot - 1, PhantomKing);
     EntityPhantomKing *kingArmR = RSDK_GET_ENTITY(kingSlot + 1, PhantomKing);
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
 
     if (!king->rubyAnimator.frameID)
         king->rubyAnimator.speed = 0;
@@ -545,7 +544,7 @@ bool32 ERZStart_Cutscene_ReturnCamToSonic(EntityCutsceneSeq *host)
 
     EntityPhantomRuby *ruby = ERZStart->ruby;
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
 
     if (host->timer == 30)
         Camera_SetupLerp(CAMERA_LERP_NORMAL, 0, ScreenInfo->center.x << 16, camera->position.y, 2);
@@ -572,7 +571,7 @@ bool32 ERZStart_Cutscene_PreparePlayerTransform(EntityCutsceneSeq *host)
 
     EntityPhantomRuby *ruby = ERZStart->ruby;
 
-    ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+    ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
 
     if (++ERZStart->timer >= 60) {
         ERZStart->timer = 0;
@@ -623,7 +622,7 @@ bool32 ERZStart_Cutscene_PlayerTransform(EntityCutsceneSeq *host)
             }
         }
         else {
-            ERZStart_HandlePlayerHover(host, player1, ruby->startPos.y);
+            ERZStart_HandlePlayerHover(player1, host, ruby->startPos.y);
         }
     }
 

--- a/SonicMania/Objects/ERZ/ERZStart.h
+++ b/SonicMania/Objects/ERZ/ERZStart.h
@@ -45,13 +45,13 @@ void ERZStart_Serialize(void);
 
 // Extra Entity Functions
 void ERZStart_SetupObjects(void);
-void ERZStart_HandlePlayerHover(EntityCutsceneSeq *seq, EntityPlayer *player, int32 posY);
+void ERZStart_HandlePlayerHover(EntityPlayer *player, EntityCutsceneSeq *seq, int32 posY);
 
 bool32 ERZStart_Cutscene_FadeIn(EntityCutsceneSeq *host);
 bool32 ERZStart_Cutscene_ShrinkRubyWarpFX(EntityCutsceneSeq *host);
 bool32 ERZStart_Cutscene_EnterKing(EntityCutsceneSeq *host);
 bool32 ERZStart_Cutscene_KingMovingRuby(EntityCutsceneSeq *host);
-bool32 ERZStart_Cutscene_KingAttatchHornRuby(EntityCutsceneSeq *host);
+bool32 ERZStart_Cutscene_KingAttachHornRuby(EntityCutsceneSeq *host);
 bool32 ERZStart_Cutscene_SetupEggmanReveal(EntityCutsceneSeq *host);
 bool32 ERZStart_Cutscene_EnterEggman(EntityCutsceneSeq *host);
 bool32 ERZStart_Cutscene_EggmanKingWrestling(EntityCutsceneSeq *host);

--- a/SonicMania/Objects/ERZ/PhantomKing.c
+++ b/SonicMania/Objects/ERZ/PhantomKing.c
@@ -112,6 +112,14 @@ void PhantomKing_CheckPlayerCollisions(void)
     }
 }
 
+void PhantomKing_Oscillate(void)
+{
+    RSDK_THIS(PhantomKing);
+
+    self->angle      = (self->angle + 3) & 0xFF;
+    self->position.y = (RSDK.Sin256(self->angle) << 10) + self->originPos.y;
+}
+
 void PhantomKing_Hit(void)
 {
     RSDK_THIS(PhantomKing);
@@ -459,7 +467,7 @@ void PhantomKing_State_InitialHover(void)
 
     RSDK.ProcessAnimation(&self->beltAnimator);
 
-    self->position.y = BadnikHelpers_Oscillate(self->originPos.y, 3, 11);
+    PhantomKing_Oscillate();
 
     PhantomKing_HandleFrames();
 
@@ -475,7 +483,7 @@ void PhantomKing_State_TakeRubyAway(void)
 
     RSDK.ProcessAnimation(&self->beltAnimator);
 
-    self->position.y = BadnikHelpers_Oscillate(self->originPos.y, 3, 11);
+    PhantomKing_Oscillate();
 
     if (self->velocity.x < 0x40000)
         self->velocity.x += 0x1800;
@@ -499,7 +507,7 @@ void PhantomKing_State_RubyHoldHover(void)
 
     RSDK.ProcessAnimation(&self->beltAnimator);
 
-    self->position.y = BadnikHelpers_Oscillate(self->originPos.y, 3, 11);
+    PhantomKing_Oscillate();
 
     PhantomKing_HandleFrames();
 }
@@ -509,8 +517,9 @@ void PhantomKing_State_WrestleEggman(void)
     RSDK_THIS(PhantomKing);
 
     RSDK.ProcessAnimation(&self->beltAnimator);
+    RSDK.ProcessAnimation(&self->rubyAnimator);
 
-    self->position.y = BadnikHelpers_Oscillate(self->originPos.y, 3, 11);
+    PhantomKing_Oscillate();
 
     self->position.x += self->velocity.x;
     self->position.y += self->velocity.y;
@@ -524,7 +533,7 @@ void PhantomKing_State_FlyAround(void)
 
     RSDK.ProcessAnimation(&self->beltAnimator);
 
-    self->position.y = BadnikHelpers_Oscillate(self->originPos.y, 3, 11);
+    PhantomKing_Oscillate();
 
     PhantomKing_CheckPlayerCollisions();
 

--- a/SonicMania/Objects/ERZ/PhantomKing.h
+++ b/SonicMania/Objects/ERZ/PhantomKing.h
@@ -79,6 +79,7 @@ void PhantomKing_Serialize(void);
 
 // Extra Entity Functions
 void PhantomKing_CheckPlayerCollisions(void);
+void PhantomKing_Oscillate(void);
 void PhantomKing_Hit(void);
 void PhantomKing_Explode(void);
 void PhantomKing_HandleFrames(void);

--- a/SonicMania/PublicFunctions.c
+++ b/SonicMania/PublicFunctions.c
@@ -858,7 +858,7 @@ void InitPublicFunctions()
     ADD_PUBLIC_FUNC(ERZStart_Cutscene_ShrinkRubyWarpFX);
     ADD_PUBLIC_FUNC(ERZStart_Cutscene_EnterKing);
     ADD_PUBLIC_FUNC(ERZStart_Cutscene_KingMovingRuby);
-    ADD_PUBLIC_FUNC(ERZStart_Cutscene_KingAttatchHornRuby);
+    ADD_PUBLIC_FUNC(ERZStart_Cutscene_KingAttachHornRuby);
     ADD_PUBLIC_FUNC(ERZStart_Cutscene_SetupEggmanReveal);
     ADD_PUBLIC_FUNC(ERZStart_Cutscene_EnterEggman);
     ADD_PUBLIC_FUNC(ERZStart_Cutscene_EggmanKingWrestling);
@@ -983,6 +983,7 @@ void InitPublicFunctions()
 
     // ERZ/PhantomKing
     ADD_PUBLIC_FUNC(PhantomKing_CheckPlayerCollisions);
+    ADD_PUBLIC_FUNC(PhantomKing_Oscillate);
     ADD_PUBLIC_FUNC(PhantomKing_Hit);
     ADD_PUBLIC_FUNC(PhantomKing_Explode);
     ADD_PUBLIC_FUNC(PhantomKing_HandleFrames);


### PR DESCRIPTION
Add missing call to SetSpriteAnimation for the ruby. The phantom ruby oscillation routine keeps the decimal part of the fixed-point Y position.

Reorder the ERZStart_HandlePlayerHover parameters to match the original. Fix small typo in (Attatch-->Attach).

Fixes #230.