### PR TITLE
Fix Podium count in the Pinball Bonus Stage

### DIFF
--- a/SonicMania/Objects/Pinball/PBL_Crane.c
+++ b/SonicMania/Objects/Pinball/PBL_Crane.c
@@ -280,7 +280,7 @@ void PBL_Crane_State_CreatePrizes(void)
     int32 spawnY = 0x600000 + self->position.y;
     self->state  = PBL_Crane_State_DisplayPrizes;
 
-    for (int32 i = 1; i < 6; ++i) {
+    for (int32 i = 0; i < 6; ++i) {
         EntityPBL_Crane *prize = CREATE_ENTITY(PBL_Crane, INT_TO_VOID(PBL_CRANE_PRIZEDISPLAY), spawnX, spawnY);
         if (globals->gameMode == MODE_ENCORE) {
             if (!((1 << i) & globals->characterFlags) || i == PBL_CRANE_PRIZE_EGGMAN) {


### PR DESCRIPTION
It was 5 when it was supposed to be 6 of them.