### PR TITLE
[MSZ] Remove copy and pasted CopyPalette in MSZSetup_Create

### DIFF
--- a/SonicMania/Objects/MSZ/MSZSetup.c
+++ b/SonicMania/Objects/MSZ/MSZSetup.c
@@ -119,7 +119,6 @@ void MSZSetup_Create(void *data)
     }
 #endif
     else {
-        RSDK.CopyPalette(0, 204, 4, 204, 4);
         RSDK.CopyPalette(3, 128, 0, 128, 128);
     }
 }


### PR DESCRIPTION
This causes Mirage Saloon act 1 background to display incorrectly compared to the steam version once the palette changes to midday.