### PR TITLE
PhantomRuby: Fix sfx type

### DIFF
--- a/SonicMania/Objects/ERZ/PhantomRuby.h
+++ b/SonicMania/Objects/ERZ/PhantomRuby.h
@@ -30,7 +30,7 @@ struct EntityPhantomRuby {
     int32 timer;
     bool32 flashFinished;
     bool32 hasFlashed;
-    int32 sfx;
+    uint8 sfx;
     int32 unused1;
     int32 unused2;
     Animator rubyAnimator;


### PR DESCRIPTION
In PhantomRuby_Serialize, the actual type for sfx is uint8.
That sound effect would fail to play on big endian platforms (Wii/WiiU).