### PR TITLE
GameLink: Add/Use EntityBase struct

### DIFF
--- a/SonicMania/GameLink.h
+++ b/SonicMania/GameLink.h
@@ -245,7 +245,13 @@ typedef struct {
     uint8 onScreen;
 #endif
 
-#define ENTITY_SIZE (sizeof(Entity) + (0x100 * sizeof(void *)))
+typedef struct {
+    RSDK_ENTITY
+    void *data[0x100];
+#if RETRO_REV0U
+    void *unknown;
+#endif
+} EntityBase;
 
 #if RETRO_REV02
 #define Unknown_pausePress  UnknownInfo->pausePress

--- a/SonicMania/Objects/AIZ/FernParallax.c
+++ b/SonicMania/Objects/AIZ/FernParallax.c
@@ -36,11 +36,11 @@ void FernParallax_Draw(void)
     thisHitbox.top    = -screen->center.y;
     thisHitbox.bottom = screen->center.y;
 
-    Entity *screenBuffer     = (Entity *)&FernParallax->entityBuffer[0 * ENTITY_SIZE];
+    EntityBase *screenBuffer = &FernParallax->entityBuffer[0];
     screenBuffer->position.x = screenX;
     screenBuffer->position.y = screenY;
 
-    Entity *entityBuffer     = (Entity *)&FernParallax->entityBuffer[1 * ENTITY_SIZE];
+    EntityBase *entityBuffer = &FernParallax->entityBuffer[1];
     entityBuffer->position.x = drawPos.x;
     entityBuffer->position.y = drawPos.y;
 
@@ -64,7 +64,7 @@ void FernParallax_Create(void *data)
 void FernParallax_StageLoad(void)
 {
     FernParallax->aniFrames = RSDK.LoadSpriteAnimation("AIZ/Decoration.bin", SCOPE_STAGE);
-    memset(FernParallax->entityBuffer, 0, 2 * ENTITY_SIZE);
+    memset(FernParallax->entityBuffer, 0, sizeof(FernParallax->entityBuffer));
 }
 
 #if GAME_INCLUDE_EDITOR

--- a/SonicMania/Objects/AIZ/FernParallax.h
+++ b/SonicMania/Objects/AIZ/FernParallax.h
@@ -8,7 +8,7 @@
 struct ObjectFernParallax {
     RSDK_OBJECT
     uint16 aniFrames;
-    uint8 entityBuffer[2 * ENTITY_SIZE];
+    EntityBase entityBuffer[2];
 };
 
 // Entity Class

--- a/SonicMania/Objects/AIZ/SchrodingersCapsule.c
+++ b/SonicMania/Objects/AIZ/SchrodingersCapsule.c
@@ -217,7 +217,7 @@ void SchrodingersCapsule_State_Explode(void)
         RSDK.SetSpriteAnimation(-1, -1, &self->rayAnimator, true, 0);
 
         EntityPlayer *buddy1 = RSDK_GET_ENTITY(SLOT_PLAYER3, Player);
-        memset(buddy1, 0, ENTITY_SIZE); // not in the original, clears the entity slot incase of something like a shield is still active
+        memset(buddy1, 0, sizeof(EntityBase)); // not in the original, clears the entity slot incase of something like a shield is still active
         buddy1->classID = Player->classID;
         Player_ChangeCharacter(buddy1, ID_MIGHTY);
         buddy1->position.x      = self->position.x + TO_FIXED(14);
@@ -240,7 +240,7 @@ void SchrodingersCapsule_State_Explode(void)
         RSDK.SetSpriteAnimation(buddy1->aniFrames, ANI_HURT, &buddy1->animator, true, 0);
 
         EntityPlayer *buddy2 = RSDK_GET_ENTITY(SLOT_PLAYER4, Player);
-        memset(buddy2, 0, ENTITY_SIZE); // like above, but for safety :]
+        memset(buddy2, 0, sizeof(EntityBase)); // like above, but for safety :]
         buddy2->classID      = Player->classID;
         Player_ChangeCharacter(buddy2, ID_RAY);
         buddy2->position.x      = self->position.x - TO_FIXED(14);

--- a/SonicMania/Objects/Global/Player.c
+++ b/SonicMania/Objects/Global/Player.c
@@ -168,7 +168,7 @@ void Player_LateUpdate(void)
 
 #if MANIA_USE_PLUS
         if (!self->sidekick)
-            RSDK.CopyEntity(Zone->entityStorage[1], self, false);
+            RSDK.CopyEntity(&Zone->entityStorage[1], self, false);
 #endif
 
         bool32 stopInvincibility = self->sidekick || globals->gameMode == MODE_COMPETITION;
@@ -3410,9 +3410,9 @@ bool32 Player_SwapMainPlayer(bool32 forceSwap)
                 destroyEntity(ice);
         }
     }
-    RSDK.CopyEntity(Zone->entityStorage, leader, false);
+    RSDK.CopyEntity(&Zone->entityStorage[0], leader, false);
     RSDK.CopyEntity(leader, sidekick, false);
-    RSDK.CopyEntity(sidekick, (Entity *)Zone->entityStorage, false);
+    RSDK.CopyEntity(sidekick, &Zone->entityStorage[0], false);
 
     sidekick->state       = Player_State_Air;
     self->controllerID    = sidekick->controllerID;
@@ -5553,7 +5553,7 @@ void Player_State_FlyToPlayer(void)
         leader = RSDK_GET_ENTITY(SLOT_PLAYER1, Player);
 #if MANIA_USE_PLUS
     else
-        leader = (EntityPlayer *)Zone->entityStorage[1];
+        leader = (EntityPlayer *)&Zone->entityStorage[1];
 #endif
 
     Player->respawnTimer = 0;
@@ -5722,7 +5722,7 @@ void Player_State_ReturnToPlayer(void)
         leader = RSDK_GET_ENTITY(SLOT_PLAYER1, Player);
 #if MANIA_USE_PLUS
     else
-        leader = (EntityPlayer *)Zone->entityStorage[1];
+        leader = (EntityPlayer *)&Zone->entityStorage[1];
 #endif
 
     RSDK.SetSpriteAnimation(self->aniFrames, ANI_JUMP, &self->animator, false, 0);

--- a/SonicMania/Objects/Global/TitleCard.c
+++ b/SonicMania/Objects/Global/TitleCard.c
@@ -99,11 +99,11 @@ void TitleCard_Create(void *data)
             SceneInfo->minutes         = globals->restartMinutes;
             SceneInfo->timeEnabled     = true;
             EntityPlayer *player       = RSDK_GET_ENTITY(SLOT_PLAYER1, Player);
-            RSDK.CopyEntity(player, (Entity *)Zone->entityStorage[0], false);
+            RSDK.CopyEntity(player, &Zone->entityStorage[0], false);
             RSDK.SetSpriteAnimation(player->aniFrames, player->animator.animationID, &player->animator, false, player->animator.frameID);
 
             if (player->camera)
-                RSDK.CopyEntity(player->camera, (Entity *)Zone->entityStorage[8], false);
+                RSDK.CopyEntity(player->camera, &Zone->entityStorage[8], false);
 
             Player_ApplyShield(player);
 
@@ -114,8 +114,8 @@ void TitleCard_Create(void *data)
             if (player->speedShoesTimer > 0 || player->superState == SUPERSTATE_SUPER)
                 RSDK.ResetEntity(RSDK_GET_ENTITY(2 * Player->playerCount + RSDK.GetEntitySlot(player), ImageTrail), ImageTrail->classID, player);
 
-            memset(Zone->entityStorage[0], 0, ENTITY_SIZE);
-            memset(Zone->entityStorage[8], 0, ENTITY_SIZE);
+            memset(&Zone->entityStorage[0], 0, sizeof(EntityBase));
+            memset(&Zone->entityStorage[8], 0, sizeof(EntityBase));
         }
 #endif
     }

--- a/SonicMania/Objects/Global/Zone.c
+++ b/SonicMania/Objects/Global/Zone.c
@@ -803,9 +803,9 @@ void Zone_State_FadeOut(void)
             globals->restartMinutes      = SceneInfo->minutes;
 
             EntityPlayer *player = RSDK_GET_ENTITY(SLOT_PLAYER1, Player);
-            RSDK.CopyEntity(Zone->entityStorage, player, false);
+            RSDK.CopyEntity(&Zone->entityStorage[0], player, false);
             if (player->camera)
-                RSDK.CopyEntity(Zone->entityStorage[8], player->camera, false);
+                RSDK.CopyEntity(&Zone->entityStorage[8], player->camera, false);
         }
 #endif
 
@@ -958,7 +958,7 @@ void Zone_HandlePlayerSwap(void)
 
     for (int32 p = 0; p < Player->playerCount; ++p) {
         EntityPlayer *player       = RSDK_GET_ENTITY(Zone->swappedPlayerIDs[p], Player);
-        EntityPlayer *storedPlayer = (EntityPlayer *)Zone->entityStorage[p];
+        EntityPlayer *storedPlayer = (EntityPlayer *)&Zone->entityStorage[p];
 
         void *state = storedPlayer->state;
         if (state == Player_State_Ground || state == Player_State_Air || state == Player_State_Roll || state == Player_State_TubeRoll
@@ -1046,10 +1046,10 @@ void Zone_HandlePlayerSwap(void)
             cam->position.y = player->position.y;
         }
 
-        memset(&Zone->entityStorage[0 + p], 0, ENTITY_SIZE);
-        memset(&Zone->entityStorage[4 + p], 0, ENTITY_SIZE);
-        memset(&Zone->entityStorage[8 + p], 0, ENTITY_SIZE);
-        memset(&Zone->entityStorage[12 + p], 0, ENTITY_SIZE);
+        memset(&Zone->entityStorage[0 + p], 0, sizeof(EntityBase));
+        memset(&Zone->entityStorage[4 + p], 0, sizeof(EntityBase));
+        memset(&Zone->entityStorage[8 + p], 0, sizeof(EntityBase));
+        memset(&Zone->entityStorage[12 + p], 0, sizeof(EntityBase));
     }
 #else
     for (int32 p = 0; p < Player->playerCount; ++p) {

--- a/SonicMania/Objects/Global/Zone.h
+++ b/SonicMania/Objects/Global/Zone.h
@@ -93,7 +93,7 @@ struct ObjectZone {
     uint8 hudDrawGroup;
     uint16 sfxFail;
 #if MANIA_USE_PLUS
-    uint8 entityStorage[16][ENTITY_SIZE];
+    EntityBase entityStorage[16];
     int32 screenPosX[PLAYER_COUNT];
     int32 screenPosY[PLAYER_COUNT];
     bool32 swapGameMode;


### PR DESCRIPTION
This struct is used Engine-side as a generic Entity type that can hold the data for any game Entity.
v5U added an extra void* field to it, making the ENTITY_SIZE macro incorrect.

Use EntityBase in some parts of the code that were using some kind of uint8 entity buffer array.

This reduces type cast alignment issues while also making the Mania code more compatible with v5U.