### PR TITLE
CMake documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,39 @@ If you want to transfer your save from the official PC versions, you can just co
 * Added all content from all released versions of the game. Including: 1.00 (Console initial release), 1.03 (PC initial release) & 1.06 (Plus update)
 
 # How to Build
-This repo includes everything you need for Sonic Mania + RSDKv5(U). It is recommended to clone this repo recursively using `git clone https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation --recursive` to build both immediately.
 
-If you wish to compile only Sonic Mania, nearly all of the dependencies can be ignored, so long as you have a build system properly setup.
+This project uses [CMake](https://cmake.org/), a versatile building system that supports many different compilers and platforms. You can download CMake [here](https://cmake.org/download/). **(Make sure to enable the feature to add CMake to the system PATH during the installation!)**
 
-## Windows
-[Install vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows), then run the following:
-- `[vcpkg root]\vcpkg.exe install libtheora libogg --triplet=x64-windows-static` (the triplet can be whatever preferred)
+## Get the source code
 
-Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=(chosen triplet)` as arguments for `cmake ..`.
+In order to clone the repository, you need to install Git, which you can get [here](https://git-scm.com/downloads).
+
+Clone the repo **recursively**, using:
+`git clone --recursive https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation`
+
+If you've already cloned the repo, run this command inside of the repository:
+```git submodule update --init```
+
+## Follow the build steps
+
+This repo includes everything you need for Sonic Mania + RSDKv5(U). If you wish to compile only Sonic Mania, you can skip to the [compilation steps below](#compiling).
+
+### Windows
+To handle dependencies, you'll need to install [Visual Studio Community](https://visualstudio.microsoft.com/downloads/) (make sure to install the `Desktop development with C++` package during the installation) and [vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows).
+
+After installing those, run the following in Command Prompt (make sure to replace `[vcpkg root]` with the path to the vcpkg installation!):
+- `[vcpkg root]/vcpkg.exe install libtheora libogg --triplet=x64-windows-static` (If you're compiling a 32-bit build, replace `x64-windows-static` with `x86-windows-static`.)
+
+Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static` as arguments for `cmake -B build`.
+  - Make sure to replace `[vcpkg root]` with the path to the vcpkg installation!
+  - If you're compiling a 32-bit build, replace `x64-windows-static` with `x86-windows-static`.
 
 ## Linux
 Install the following dependencies: then follow the [compilation steps below](#compiling):
 - **pacman (Arch):** `sudo pacman -S base-devel glew glfw libtheora portaudio`
 - **apt (Debian/Ubuntu):** `sudo apt install build-essential libglew-dev libglfw3-dev libtheora-dev portaudio19-dev`
 - **rpm (Fedora):** `sudo dnf install make gcc glew-devel glfw-devel libtheora-devel zlib-devel portaudio`
-- Your favorite package manager here, [make a pull request](https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation/fork) (also update RSDKv5U!)
+- Your favorite package manager here, [make a pull request](https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation/fork) (also update [RSDKv5U](https://github.com/Rubberduckycooly/RSDKv5-Decompilation)!)
 
 #### (make sure to [install GL shaders!](#q-why-arent-videosfilters-working-while-using-gl))
 
@@ -46,7 +63,7 @@ Install the following dependencies: then follow the [compilation steps below](#c
 [Setup devKitPro](https://devkitpro.org/wiki/Getting_Started), then run the following:
 - `(dkp-)pacman -Syuu switch-dev switch-libogg switch-libtheora switch-sdl2 switch-glad`
 
-Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Platform/Switch.cmake` as arguments for `cmake ..`.
+Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Platform/Switch.cmake` as arguments for `cmake -B build`.
 
 #### (make sure to [install GL shaders!](#q-why-arent-videosfilters-working-while-using-gl))
 
@@ -57,28 +74,29 @@ Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHA
 
 Compiling is as simple as typing the following:
 ```
-cmake -Bbuild # arguments go here
-cmake --build build
+cmake -B build
+cmake --build build --config release
 ```
 
 The resulting build for Mania will be located somewhere in `build/` depending on your system.
 If building with RSDKv5(U), the resulting Mania and RSDK executable will likely be in `build/dependencies/RSDKv5/`.
 
 The following cmake arguments are available when compiling:
-- Use these on the `cmake ..` step like so: `cmake .. -DRETRO_DISABLE_PLUS=on`
+- Use these on the `cmake -B build` step like so: `cmake -B build -DRETRO_DISABLE_PLUS=on`
 
 ### RSDKv5 flags
 - `RETRO_REVISION`: What revision to compile for. Takes an integer, defaults to `3` (RSDKv5U).
 - `RETRO_DISABLE_PLUS`: Whether or not to disable the Plus DLC. Takes a boolean (on/off): build with `on` when compiling for distribution. Defaults to `off`.
 - `RETRO_MOD_LOADER`: Enables or disables the mod loader. Takes a boolean, defaults to `on`.
 - `RETRO_MOD_LOADER_VER`: Manually sets the mod loader version. Takes an integer, defaults to the current latest version.
-- `RETRO_SUBSYSTEM`: *Only change this if you know what you're doing.* Changes the subsystem that RSDKv5 will be built for. Defaults to the most standard subsystem for the platform.   
+- `RETRO_SUBSYSTEM`: *Only change this if you know what you're doing.* Changes the subsystem that RSDKv5 will be built for. Defaults to the most standard subsystem for the platform.
 
 ### Sonic Mania flags
-- `WITH_RSDK`= Whether or not RSDKv5 is built alongside Sonic Mania. Takes a boolean, defaults to `off`.
+- `WITH_RSDK`: Whether or not RSDKv5 is built alongside Sonic Mania. Takes a boolean, defaults to `off`.
   - `GAME_STATIC`: Whether or not to build Sonic Mania into the resulting RSDKv5 executable. Takes a boolean, defaults change depending on the system.
-- `MANIA_FIRST_RELEASE`: Whether or not to build the first release of Sonic Mania. Takes a boolean, defaults to `off`.
-- `MANIA_PRE_PLUS`: Whether or not to build a pre-plus verion of Sonic Manhia. Takes a boolea, defaults to `off`.
+- `MANIA_FIRST_RELEASE`: Whether or not to build the first console release of Sonic Mania. Takes a boolean, defaults to `off`.
+- `MANIA_PRE_PLUS`: Whether or not to build a pre-plus version of Sonic Mania. Takes a boolean, defaults to `off`.
+- `GAME_INCLUDE_EDITOR`: Whether or not to include functions for use in certain RSDKv5 scene editors. Takes a boolean, defaults to `on`.
 - `GAME_VERSION`: Which release version of Sonic Mania to target for. Takes an integer, defaults to `3` when `MANIA_PRE_PLUS` is enabled, and `6` otherwise (last steam release).
 
 ### Other Platforms
@@ -113,8 +131,8 @@ A: Submit an issue in the issues tab and we _might_ fix it in the main branch. D
 ### Q: Will you do a decompilation for Sonic CD (2011) and/or Sonic 1/2 (2013)?
 A: I already have! You can find Sonic CD [here](https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation) and Sonic 1/2 [here](https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation).
 
-### Q: Are there anymore decompilation projects in the works, such as Sonic Origins/Sonic 3?
-A: Absolutely not. This project took about 1 and a half years to do, and doing Sonic 3 would take equally as long, if not longer, as Sonic 3 is not only larger in scope, but Origins' hybrid codebase makes it harder to read. Between our other decompilation projects and this one, we're done with decompiling, at least for the time being. We would also like to expand our horizons beyond Sonic going forward, and we don't wish to spend forever just playing catchup with Sega's official releases. Please do not expect any more decompilations from us, Sonic or otherwise!
+### Q: Are there anymore decompilation projects in the works, such as Sonic Origins/Sonic 3 & Knuckles?
+A: Absolutely not. This project took about 1 and a half years to do, and doing Sonic 3 & Knuckles would take equally as long, if not longer, as it's not only larger in scope, but Origins' hybrid codebase makes it harder to read. Between our other decompilation projects and this one, we're done with decompiling, at least for the time being. We would also like to expand our horizons beyond Sonic going forward, and we don't wish to spend forever just playing catchup with Sega's official releases. Please do not expect any more decompilations from us, Sonic or otherwise!
 
 # Special Thanks
 * [st×tic](https://github.com/stxticOVFL) for leading ModAPI development, porting to other platforms, general decompilation assistance, helping me fix bugs, tweaking up my sometimes sloppy code and generally being really helpful and fun to work with on this project

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHA
 
 ### Compiling
 
-Compiling is as simple as typing the following:
+Compiling is as simple as typing the following in the root repository directory:
 ```
 cmake -B build
 cmake --build build --config release

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to transfer your save from the official PC versions, you can just co
 
 # How to Build
 
-This project uses [CMake](https://cmake.org/), a versatile building system that supports many different compilers and platforms. You can download CMake [here](https://cmake.org/download/). **(Make sure to enable the feature to add CMake to the system PATH during the installation!)**
+This project uses [CMake](https://cmake.org/), a versatile building system that supports many different compilers and platforms. You can download CMake [here](https://cmake.org/download/). **(Make sure to enable the feature to add CMake to the system PATH during the installation if you're on Windows!)**
 
 ## Get the source code
 


### PR DESCRIPTION
This carries over some of the improvements to the CMake documentation/building instructions made in the RSDKv3 and RSDKv4 repositories, and generally cleans up some minor things.