### PR TITLE
Fix recursive line in Git clone step

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project uses [CMake](https://cmake.org/), a versatile building system that 
 In order to clone the repository, you need to install Git, which you can get [here](https://git-scm.com/downloads).
 
 Clone the repo **recursively**, using:
-`git clone --recursive https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation`
+`git clone https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation --recursive`
 
 If you've already cloned the repo, run this command inside of the repository:
 ```git submodule update --init```


### PR DESCRIPTION
This moves `--recursive` from the middle of the Git pull command to the end to prevent potential user errors.

Also can we get cmake-docs merged into main it's been over half a year