### PR TITLE
Minor fixes to certain parts of the decomp's code

### DIFF
--- a/SonicMania/Objects/MSZ/MSZSetup.c
+++ b/SonicMania/Objects/MSZ/MSZSetup.c
@@ -119,6 +119,7 @@ void MSZSetup_Create(void *data)
     }
 #endif
     else {
+        RSDK.CopyPalette(0, 204, 4, 204, 4);
         RSDK.CopyPalette(3, 128, 0, 128, 128);
     }
 }

--- a/SonicMania/Objects/MSZ/MSZSetup.c
+++ b/SonicMania/Objects/MSZ/MSZSetup.c
@@ -119,7 +119,7 @@ void MSZSetup_Create(void *data)
     }
 #endif
     else {
-#if MANIA_PREPLUS
+#if !MANIA_USE_PLUS
         RSDK.CopyPalette(0, 204, 4, 204, 4);
 #endif
         RSDK.CopyPalette(3, 128, 0, 128, 128);

--- a/SonicMania/Objects/MSZ/MSZSetup.c
+++ b/SonicMania/Objects/MSZ/MSZSetup.c
@@ -119,7 +119,9 @@ void MSZSetup_Create(void *data)
     }
 #endif
     else {
+#if MANIA_PREPLUS
         RSDK.CopyPalette(0, 204, 4, 204, 4);
+#endif
         RSDK.CopyPalette(3, 128, 0, 128, 128);
     }
 }

--- a/SonicMania/Objects/Menu/UIVsCharSelector.c
+++ b/SonicMania/Objects/Menu/UIVsCharSelector.c
@@ -248,7 +248,7 @@ void UIVsCharSelector_ProcessButtonCB(void)
         while (self->frameID < 0) self->frameID += max;
         while (self->frameID >= max) self->frameID -= max;
 
-#if MANIA_PREPLUS
+#if MANIA_USE_PLUS
         int32 activePlayers = 0;
 
         for (int32 i = 0; i < parent->buttonCount; ++i) {

--- a/SonicMania/Objects/Menu/UIVsCharSelector.c
+++ b/SonicMania/Objects/Menu/UIVsCharSelector.c
@@ -248,7 +248,7 @@ void UIVsCharSelector_ProcessButtonCB(void)
         while (self->frameID < 0) self->frameID += max;
         while (self->frameID >= max) self->frameID -= max;
 
-#if !MANIA_USE_PLUS
+#if MANIA_PREPLUS
         int32 activePlayers = 0;
 
         for (int32 i = 0; i < parent->buttonCount; ++i) {

--- a/SonicMania/Objects/Menu/UIVsCharSelector.c
+++ b/SonicMania/Objects/Menu/UIVsCharSelector.c
@@ -248,7 +248,7 @@ void UIVsCharSelector_ProcessButtonCB(void)
         while (self->frameID < 0) self->frameID += max;
         while (self->frameID >= max) self->frameID -= max;
 
-#if GAME_VERSION != VER_100
+#if !MANIA_USE_PLUS
         int32 activePlayers = 0;
 
         for (int32 i = 0; i < parent->buttonCount; ++i) {

--- a/SonicMania/SonicMania_All.vcxproj
+++ b/SonicMania/SonicMania_All.vcxproj
@@ -4326,6 +4326,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Game.rc" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>

--- a/SonicMania/SonicMania_All.vcxproj.filters
+++ b/SonicMania/SonicMania_All.vcxproj.filters
@@ -3779,4 +3779,9 @@
       <Filter>Sources</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Game.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
 </Project>

--- a/SonicMania/SonicMania_All_PrePlus.vcxproj
+++ b/SonicMania/SonicMania_All_PrePlus.vcxproj
@@ -4326,6 +4326,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Game.rc" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>

--- a/SonicMania/SonicMania_All_PrePlus.vcxproj.filters
+++ b/SonicMania/SonicMania_All_PrePlus.vcxproj.filters
@@ -3779,4 +3779,9 @@
       <Filter>Sources</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Game.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
 </Project>

--- a/SonicMania/SonicMania_All_Rev0U.vcxproj
+++ b/SonicMania/SonicMania_All_Rev0U.vcxproj
@@ -4326,6 +4326,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Game.rc" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>

--- a/SonicMania/SonicMania_All_Rev0U.vcxproj.filters
+++ b/SonicMania/SonicMania_All_Rev0U.vcxproj.filters
@@ -3779,4 +3779,9 @@
       <Filter>Sources</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Game.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
this pull request may close the following issues:
#267 - Not selecting the same character in PrePlus versions of the game
#268 - Mirage Saloon Zone Act 1's background palette not changing.
#269 - a version resource file not available within the "All" configs of the Visual Studio projects.

while not pushed to the main repo yet, I believe that this should be a quick way to take care of them entirely, alongside avoiding potential future issues in the long run.